### PR TITLE
improve comments for pattern, rename isPatternExpr

### DIFF
--- a/v3/memo.go
+++ b/v3/memo.go
@@ -22,7 +22,7 @@ type memoExpr struct {
 }
 
 func (e *memoExpr) match(pattern *expr) bool {
-	return isPatternExpr(pattern) || pattern.op == e.op
+	return isPatternSentinel(pattern) || pattern.op == e.op
 }
 
 // fingerprint returns a string which uniquely identifies the expression within
@@ -286,7 +286,7 @@ func (m *memo) bind(e *memoExpr, pattern, cursor *expr) *expr {
 					// Pattern failed to match.
 					return nil
 				}
-			} else if !isPatternExpr(childPattern) {
+			} else if !isPatternSentinel(childPattern) {
 				// No child present and pattern failed to match.
 				return nil
 			}

--- a/v3/pattern.go
+++ b/v3/pattern.go
@@ -64,7 +64,7 @@ package v3
 var patternLeaf = &expr{}
 var patternTree = &expr{}
 
-func isPatternExpr(pattern *expr) bool {
+func isPatternSentinel(pattern *expr) bool {
 	return isPatternLeaf(pattern) || isPatternTree(pattern)
 }
 
@@ -81,7 +81,7 @@ func isPatternTree(pattern *expr) bool {
 // memo. If an expression has been extracted from the memo using memo.bind() it
 // is not necessary to match against the pattern used for extraction again.
 func patternMatch(pattern, e *expr) bool {
-	if isPatternExpr(pattern) {
+	if isPatternSentinel(pattern) {
 		return true
 	}
 	if pattern.op != e.op {
@@ -95,7 +95,7 @@ func patternMatch(pattern, e *expr) bool {
 			if !patternMatch(pattern.children[i], e.children[i]) {
 				return false
 			}
-		} else if !isPatternExpr(pattern.children[i]) {
+		} else if !isPatternSentinel(pattern.children[i]) {
 			return false
 		}
 	}

--- a/v3/xform.go
+++ b/v3/xform.go
@@ -80,7 +80,7 @@ var implementationXforms = [numOperators][]xformID{}
 
 func registerXform(xform xform) {
 	p := xform.pattern()
-	if isPatternExpr(p) {
+	if isPatternSentinel(p) {
 		fatalf("patterns need to be rooted in a non-pattern operator: %s", p)
 	}
 


### PR DESCRIPTION
#### improve comments for pattern

#### rename isPatternExpr

We define "pattern expression" as the entire pattern tree, which makes
isPatternExpr a misnomer. Renaming to `isPatternLeafOrTree`.
