### PR TITLE
Adjust logical equivalency for expressions

### DIFF
--- a/v3/group.go
+++ b/v3/group.go
@@ -47,3 +47,7 @@ func (groupBy) updateProps(e *expr) {
 
 	e.props.applyInputs(e.inputs())
 }
+
+func (groupBy) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}

--- a/v3/index_join.go
+++ b/v3/index_join.go
@@ -26,3 +26,7 @@ func (indexJoin) initKeys(e *expr, state *queryState) {
 func (indexJoin) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 }
+
+func (indexJoin) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}

--- a/v3/index_scan.go
+++ b/v3/index_scan.go
@@ -72,3 +72,7 @@ func (indexScan) initKeys(e *expr, state *queryState) {
 func (indexScan) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 }
+
+func (indexScan) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}

--- a/v3/index_scan.go
+++ b/v3/index_scan.go
@@ -39,12 +39,6 @@ func newIndexScanExpr(table *table, key *tableKey, scanProps *relationalProps) *
 		for _, i := range key.columns {
 			indexScan.props.columns = append(indexScan.props.columns, scanProps.columns[i])
 		}
-		// TODO(peter): we set parts of the index scan properties to match the scan
-		// properties so that their fingerprints match, ensuring they map to the
-		// same group in the memo.
-		indexScan.props.notNullCols = scanProps.notNullCols
-		indexScan.props.weakKeys = scanProps.weakKeys
-		indexScan.props.foreignKeys = scanProps.foreignKeys
 		indexScan.initProps()
 	}
 

--- a/v3/join.go
+++ b/v3/join.go
@@ -59,6 +59,10 @@ func (join) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
+func (join) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}
+
 func joinOp(s string) operator {
 	switch s {
 	case "JOIN", "INNER JOIN", "CROSS JOIN":

--- a/v3/memo.go
+++ b/v3/memo.go
@@ -281,19 +281,22 @@ func (m *memo) addExpr(e *expr) groupID {
 	}
 
 	ef := me.fingerprint()
+	if group, ok := m.exprMap[ef]; ok {
+		// The expression already exists in the memo.
+		return group
+	}
+
 	if me.loc.group == 0 {
-		group, ok := m.exprMap[ef]
+		// Determine which group the expression belongs in, creating it if
+		// necessary.
+		gf := me.groupFingerprint()
+		group, ok := m.groupMap[gf]
 		if !ok {
-			// Determine which group the expression belongs in, creating it if
-			// necessary.
-			gf := me.groupFingerprint()
-			if group, ok = m.groupMap[gf]; !ok {
-				group = groupID(len(m.groups))
-				g := newMemoGroup(e.props, e.scalarProps)
-				g.id = group
-				m.groups = append(m.groups, g)
-				m.groupMap[gf] = group
-			}
+			group = groupID(len(m.groups))
+			g := newMemoGroup(e.props, e.scalarProps)
+			g.id = group
+			m.groups = append(m.groups, g)
+			m.groupMap[gf] = group
 		}
 		me.loc.group = group
 	}

--- a/v3/memo.go
+++ b/v3/memo.go
@@ -128,6 +128,10 @@ func (e *memoExpr) groupFingerprint() string {
 	return buf.String()
 }
 
+func (e *memoExpr) info() operatorInfo {
+	return operatorTab[e.op]
+}
+
 // memoGroup stores a set of logically equivalent expressions. See the comments
 // on memoExpr for the definition of logical equivalency.
 type memoGroup struct {

--- a/v3/operator.go
+++ b/v3/operator.go
@@ -125,6 +125,10 @@ type operatorInfo interface {
 	// Update the logical properties based on the internal state of the
 	// expression.
 	updateProps(e *expr)
+
+	// Compute the required physical properties for the specified child given
+	// required properties on the receiver.
+	requiredProps(required *physicalProps, child int) *physicalProps
 }
 
 var (

--- a/v3/order.go
+++ b/v3/order.go
@@ -37,6 +37,10 @@ func (orderBy) initKeys(e *expr, state *queryState) {
 func (orderBy) updateProps(e *expr) {
 }
 
+func (orderBy) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}
+
 // orderSpec defines the ordering of columns provided or required by a
 // relation. A negative value indicates descending ordering on the column index
 // "-(value+1)".

--- a/v3/project.go
+++ b/v3/project.go
@@ -45,3 +45,7 @@ func (project) updateProps(e *expr) {
 
 	e.props.applyInputs(e.inputs())
 }
+
+func (project) requiredProps(required *physicalProps, child int) *physicalProps {
+	return required // pass through
+}

--- a/v3/relational_props.go
+++ b/v3/relational_props.go
@@ -123,10 +123,6 @@ type relationalProps struct {
 
 	// The number of joins that have been performed at and below this relation.
 	joinDepth int32
-
-	// TODO(peter): This is a hack until constraints are present. If the
-	// expression contains filters, we need to distinguish it from its input.
-	constraints bool
 }
 
 func (p *relationalProps) init() {
@@ -177,44 +173,6 @@ func (p *relationalProps) format(buf *bytes.Buffer, level int) {
 		}
 		buf.WriteString("\n")
 	}
-}
-
-// fingerprint returns a string which uniquely identifies the relational
-// properties within the context of a query.
-func (p *relationalProps) fingerprint() string {
-	// TODO(peter): The fingerprint is unique, but human readable. A binary
-	// format encoding columns and keys using varints might be faster and more
-	// compact.
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "[out=%s outer=%s not-null=%s]", p.outputCols, p.outerCols, p.notNullCols)
-	if len(p.weakKeys) > 0 {
-		buf.WriteString(" keys=[")
-		for i, key := range p.weakKeys {
-			if i > 0 {
-				buf.WriteString(" ")
-			}
-			fmt.Fprintf(&buf, "%s", key)
-		}
-		buf.WriteString("]")
-	}
-	if len(p.foreignKeys) > 0 {
-		buf.WriteString(" fkeys=[")
-		for i, fkey := range p.foreignKeys {
-			if i > 0 {
-				buf.WriteString(" ")
-			}
-			fmt.Fprintf(&buf, "%s->%s", fkey.src, fkey.dest)
-		}
-		buf.WriteString("]")
-	}
-	if p.joinDepth > 0 {
-		fmt.Fprintf(&buf, " join=%d", p.joinDepth)
-	}
-	// TODO(peter): see comment about "constraints" field.
-	if p.constraints {
-		fmt.Fprintf(&buf, " C")
-	}
-	return buf.String()
 }
 
 func (p *relationalProps) findColumn(name string) *columnProps {

--- a/v3/rename.go
+++ b/v3/rename.go
@@ -44,3 +44,7 @@ func (rename) updateProps(e *expr) {
 
 	e.props.applyInputs(e.inputs())
 }
+
+func (rename) requiredProps(required *physicalProps, child int) *physicalProps {
+	return required // pass through
+}

--- a/v3/scalar.go
+++ b/v3/scalar.go
@@ -137,6 +137,10 @@ func (scalar) updateProps(e *expr) {
 	}
 }
 
+func (scalar) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}
+
 func substitute(e *expr, columns bitmap, replacement *expr) *expr {
 	if e.op == variableOp {
 		if e.scalarInputCols() == columns {

--- a/v3/scan.go
+++ b/v3/scan.go
@@ -62,3 +62,7 @@ func (scan) initKeys(e *expr, state *queryState) {
 func (scan) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 }
+
+func (scan) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}

--- a/v3/search.go
+++ b/v3/search.go
@@ -233,13 +233,9 @@ func (s *search) optimizeGroup(loc memoLoc, required *physicalProps, parent *sea
 		t.required = required
 
 		// Optimize children groups.
-		//
-		// TODO(peter): some operators are pass through for the required properties
-		// while other operators need to derive new properties for each child. For
-		// now, we're always passing through the required properties, but that is
-		// definitely not correct.
-		for _, c := range e.children {
-			s.optimizeGroupTask(s.memo.groups[c], required, t)
+		op := e.info()
+		for i, c := range e.children {
+			s.optimizeGroupTask(s.memo.groups[c], op.requiredProps(required, i), t)
 		}
 
 		s.schedule(t)

--- a/v3/select.go
+++ b/v3/select.go
@@ -50,3 +50,7 @@ func (sel) updateProps(e *expr) {
 	e.props.applyFilters(e.filters())
 	e.props.applyInputs(e.inputs())
 }
+
+func (sel) requiredProps(required *physicalProps, child int) *physicalProps {
+	return required // pass through
+}

--- a/v3/select.go
+++ b/v3/select.go
@@ -49,6 +49,4 @@ func (sel) updateProps(e *expr) {
 
 	e.props.applyFilters(e.filters())
 	e.props.applyInputs(e.inputs())
-
-	e.props.constraints = true
 }

--- a/v3/select_to_index_scan.go
+++ b/v3/select_to_index_scan.go
@@ -70,6 +70,7 @@ func (selectToIndexScan) apply(e *expr, results []*expr) []*expr {
 				}
 				indexScan.initProps()
 			}
+			indexScan.loc = memoLoc{group: scan.loc.group, expr: -1}
 
 			results = append(results, &expr{
 				op: selectOp,

--- a/v3/set.go
+++ b/v3/set.go
@@ -46,3 +46,7 @@ func (union) updateProps(e *expr) {
 
 	e.props.applyInputs(e.inputs())
 }
+
+func (union) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}

--- a/v3/sort.go
+++ b/v3/sort.go
@@ -37,3 +37,9 @@ func (sorter) initKeys(e *expr, state *queryState) {
 
 func (sorter) updateProps(e *expr) {
 }
+
+func (sorter) requiredProps(required *physicalProps, child int) *physicalProps {
+	// A sort expression enforces ordering and does not require any specific
+	// ordering from its input.
+	return nil
+}

--- a/v3/testdata/group
+++ b/v3/testdata/group
@@ -146,3 +146,23 @@ project [out=(0,3)]
               inputs:
                 scan [out=(0,1)]
                   columns: a.x:0 a.y:1
+
+# This query is artificial and is intended only to highlight that the
+# two group-by expressions are placed in different groups in the memo.
+
+prep,memo
+SELECT SUM(x) FROM a GROUP BY x UNION SELECT SUM(x) FROM a WHERE y > 1 GROUP BY y
+----
+13: [union [6 12]]
+12: [project [11 5]]
+11: [groupBy [10 7 3]]
+10: [select [1 9]]
+9: [comp (>) [7 8]]
+8: [const 1]
+7: [variable a.y]
+6: [project [4 5]]
+5: [variable column3]
+4: [groupBy [1 2 3]]
+3: [func sum [2]]
+2: [variable a.x]
+1: [scan a]

--- a/v3/testdata/union
+++ b/v3/testdata/union
@@ -5,12 +5,8 @@ table a
   x NULL
   y NULL
 
-# TODO(peter): The union expression should not be mapped to the same
-# group as the scan expression. It currently is because there are no
-# changes to the relational properties of the union expression to
-# distinguish it from the scan expression.
-
 prep,memo
 SELECT * FROM a UNION ALL SELECT * from a
 ----
-1: [scan a] [union [1 1]]
+2: [union [1 1]]
+1: [scan a]

--- a/v3/variable.go
+++ b/v3/variable.go
@@ -42,3 +42,7 @@ func (variable) initKeys(e *expr, state *queryState) {
 
 func (variable) updateProps(e *expr) {
 }
+
+func (variable) requiredProps(required *physicalProps, child int) *physicalProps {
+	return nil
+}


### PR DESCRIPTION
Previously, logical equivalency for expressions was defined as
equivalent relational properties. But this is too high of a bar to reach
as we need to ensure that the relational properties encode all of the
differences between expressions. Now we invert the default and assume
two expressions are not equivalent without specific handling. In
particular, this change only allows logical equivalency between
expressions when adding transformed expressions back into the memo and
between inner-join expressions (see `memoExpr.groupFingerprint()`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/27)
<!-- Reviewable:end -->
