### PR TITLE
add tableName, columnName

### DIFF
--- a/v3/build.go
+++ b/v3/build.go
@@ -109,7 +109,7 @@ func buildTable(texpr tree.TableExpr, scope *scope) *expr {
 			for i := range result.props.columns {
 				col := &result.props.columns[i]
 				if i < len(source.As.Cols) {
-					col.name = string(source.As.Cols[i])
+					col.name = columnName(source.As.Cols[i])
 				}
 				col.table = tableName(source.As.Alias)
 			}
@@ -235,9 +235,9 @@ func buildUsingJoin(e *expr, names tree.NameList) {
 	right := inputs[1].props
 	e.props.columns = make([]columnProps, 0, len(left.columns)+len(right.columns))
 
-	joined := make(map[string]*columnProps, len(names))
+	joined := make(map[columnName]*columnProps, len(names))
 	for _, name := range names {
-		name := string(name)
+		name := columnName(name)
 		// For every adjacent pair of tables, add an equality predicate.
 		leftCol := left.findColumn(name)
 		if leftCol == nil {
@@ -300,7 +300,7 @@ func buildScalar(pexpr tree.Expr, scope *scope) *expr {
 
 	case *tree.ColumnItem:
 		tblName := tableName(t.TableName.Table())
-		colName := string(t.ColumnName)
+		colName := columnName(t.ColumnName)
 
 		for s := scope; s != nil; s = s.parent {
 			for _, col := range s.props.columns {
@@ -480,7 +480,7 @@ func buildGroupByExtractAggregates(g *expr, e *expr, scope *scope) bool {
 
 		index := scope.state.nextVar
 		scope.state.nextVar++
-		name := fmt.Sprintf("column%d", len(g.props.columns)+1)
+		name := columnName(fmt.Sprintf("column%d", len(g.props.columns)+1))
 		g.props.columns = append(g.props.columns, columnProps{
 			index: index,
 			name:  name,
@@ -567,13 +567,13 @@ func buildProjections(
 				input.initProps()
 			}
 
-			name := string(sexpr.As)
+			name := columnName(sexpr.As)
 			if p.op != variableOp {
 				passthru = false
 				index := scope.state.nextVar
 				scope.state.nextVar++
 				if name == "" {
-					name = fmt.Sprintf("column%d", len(result.props.columns)+1)
+					name = columnName(fmt.Sprintf("column%d", len(result.props.columns)+1))
 				}
 				p.scalarProps.definedCols.Add(index)
 				result.props.columns = append(result.props.columns, columnProps{

--- a/v3/build.go
+++ b/v3/build.go
@@ -86,11 +86,11 @@ func build(stmt tree.Statement, scope *scope) *expr {
 func buildTable(texpr tree.TableExpr, scope *scope) *expr {
 	switch source := texpr.(type) {
 	case *tree.NormalizableTableName:
-		tableName, err := source.Normalize()
+		tn, err := source.Normalize()
 		if err != nil {
 			fatalf("%s", err)
 		}
-		name := tableName.Table()
+		name := tableName(tn.Table())
 		tab, ok := scope.state.catalog[name]
 		if !ok {
 			fatalf("unknown table %s", name)
@@ -111,7 +111,7 @@ func buildTable(texpr tree.TableExpr, scope *scope) *expr {
 				if i < len(source.As.Cols) {
 					col.name = string(source.As.Cols[i])
 				}
-				col.table = string(source.As.Alias)
+				col.table = tableName(source.As.Alias)
 			}
 		}
 		return result
@@ -299,13 +299,13 @@ func buildScalar(pexpr tree.Expr, scope *scope) *expr {
 		result = newUnaryExpr(unaryOpMap[t.Operator], buildScalar(t.Expr, scope))
 
 	case *tree.ColumnItem:
-		tableName := t.TableName.Table()
+		tblName := tableName(t.TableName.Table())
 		colName := string(t.ColumnName)
 
 		for s := scope; s != nil; s = s.parent {
 			for _, col := range s.props.columns {
-				if col.hasColumn(tableName, colName) {
-					if tableName == "" && col.table != "" {
+				if col.hasColumn(tblName, colName) {
+					if tblName == "" && col.table != "" {
 						t.TableName.TableName = tree.Name(col.table)
 						t.TableName.DBNameOriginallyOmitted = true
 					}
@@ -514,7 +514,7 @@ func buildProjection(pexpr tree.Expr, scope *scope) []*expr {
 		return projections
 
 	case *tree.AllColumnsSelector:
-		tableName := t.TableName.Table()
+		tableName := tableName(t.TableName.Table())
 		var projections []*expr
 		for _, col := range scope.props.columns {
 			if !col.hidden && col.table == tableName {

--- a/v3/index_scan.go
+++ b/v3/index_scan.go
@@ -1,6 +1,9 @@
 package v3
 
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+)
 
 func init() {
 	registerOperator(indexScanOp, "index-scan", indexScan{})
@@ -8,7 +11,7 @@ func init() {
 
 func newIndexScanExpr(table *table, key *tableKey, scanProps *relationalProps) *expr {
 	index := *table
-	index.name += "@" + key.name
+	index.name = tableName(fmt.Sprintf("%s@%s", table.name, key.name))
 	indexScan := &expr{
 		op:       indexScanOp,
 		children: []*expr{nil /* projections */},

--- a/v3/planner.go
+++ b/v3/planner.go
@@ -47,7 +47,9 @@ func (p *planner) exec(stmt tree.Statement) string {
 		// The histogram.table.column tokens map to
 		// PrefixName.DatabaseName.TableName. So we get the table name from
 		// DatabaseName and the column name from TableName.
-		h := createHistogram(p.catalog, tableName(tname.DatabaseName), string(tname.TableName), stmt.Rows)
+		h := createHistogram(
+			p.catalog, tableName(tname.DatabaseName), columnName(tname.TableName), stmt.Rows,
+		)
 		return h.String()
 	default:
 		unimplemented("%T", stmt)

--- a/v3/planner.go
+++ b/v3/planner.go
@@ -15,12 +15,12 @@ func fatalf(format string, args ...interface{}) {
 }
 
 type planner struct {
-	catalog map[string]*table
+	catalog map[tableName]*table
 }
 
 func newPlanner() *planner {
 	return &planner{
-		catalog: make(map[string]*table),
+		catalog: make(map[tableName]*table),
 	}
 }
 
@@ -41,7 +41,13 @@ func (p *planner) exec(stmt tree.Statement) string {
 		if tname.PrefixName != "histogram" {
 			unimplemented("%s", stmt)
 		}
-		h := createHistogram(p.catalog, string(tname.DatabaseName), string(tname.TableName), stmt.Rows)
+		// This is a statement of the form
+		//   INSERT INTO histogram.table.column VALUES ...
+		//
+		// The histogram.table.column tokens map to
+		// PrefixName.DatabaseName.TableName. So we get the table name from
+		// DatabaseName and the column name from TableName.
+		h := createHistogram(p.catalog, tableName(tname.DatabaseName), string(tname.TableName), stmt.Rows)
 		return h.String()
 	default:
 		unimplemented("%T", stmt)
@@ -52,7 +58,7 @@ func (p *planner) exec(stmt tree.Statement) string {
 func (p *planner) build(stmt tree.Statement) *expr {
 	state := &queryState{
 		catalog: p.catalog,
-		tables:  make(map[string]bitmapIndex),
+		tables:  make(map[tableName]bitmapIndex),
 	}
 	e := build(stmt, &scope{
 		props: &relationalProps{},

--- a/v3/relational_props.go
+++ b/v3/relational_props.go
@@ -7,18 +7,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-// queryState holds per-query state such as the tables referenced by the query
-// and the mapping from table name to the column index for those tables columns
-// within the query.
+// queryState holds per-query state
 type queryState struct {
-	catalog map[string]*table
-	tables  map[string]bitmapIndex
+	// map from table name to table
+	catalog map[tableName]*table
+	// map from table name to the column index for the table's columns within the
+	// query (they form a contiguous group starting at this index).
+	tables map[tableName]bitmapIndex
+	// nextVar keeps track of the next index for a column (used during build).
 	nextVar bitmapIndex
 }
 
 type columnProps struct {
 	name   string
-	table  string
+	table  tableName
 	index  bitmapIndex
 	hidden bool
 }
@@ -30,19 +32,19 @@ func (c columnProps) String() string {
 	return fmt.Sprintf("%s.%s", tree.Name(c.table), tree.Name(c.name))
 }
 
-func (c columnProps) hasColumn(tableName, colName string) bool {
+func (c columnProps) hasColumn(tblName tableName, colName string) bool {
 	if colName != c.name {
 		return false
 	}
-	if tableName == "" {
+	if tblName == "" {
 		return true
 	}
-	return c.table == tableName
+	return c.table == tblName
 }
 
-func (c columnProps) newVariableExpr(tableName string) *expr {
-	if tableName != "" {
-		c.table = tableName
+func (c columnProps) newVariableExpr(table tableName) *expr {
+	if table != "" {
+		c.table = table
 	}
 	return newVariableExpr(c, c.index)
 }
@@ -143,7 +145,7 @@ func (p *relationalProps) format(buf *bytes.Buffer, level int) {
 		if col.hidden {
 			buf.WriteString("(")
 		}
-		buf.WriteString(col.table)
+		buf.WriteString(string(col.table))
 		buf.WriteString(".")
 		buf.WriteString(col.name)
 		buf.WriteString(":")

--- a/v3/relational_props.go
+++ b/v3/relational_props.go
@@ -19,7 +19,7 @@ type queryState struct {
 }
 
 type columnProps struct {
-	name   string
+	name   columnName
 	table  tableName
 	index  bitmapIndex
 	hidden bool
@@ -32,7 +32,7 @@ func (c columnProps) String() string {
 	return fmt.Sprintf("%s.%s", tree.Name(c.table), tree.Name(c.name))
 }
 
-func (c columnProps) hasColumn(tblName tableName, colName string) bool {
+func (c columnProps) hasColumn(tblName tableName, colName columnName) bool {
 	if colName != c.name {
 		return false
 	}
@@ -147,7 +147,7 @@ func (p *relationalProps) format(buf *bytes.Buffer, level int) {
 		}
 		buf.WriteString(string(col.table))
 		buf.WriteString(".")
-		buf.WriteString(col.name)
+		buf.WriteString(string(col.name))
 		buf.WriteString(":")
 		fmt.Fprintf(buf, "%d", col.index)
 		if p.notNullCols.Contains(col.index) {
@@ -177,7 +177,7 @@ func (p *relationalProps) format(buf *bytes.Buffer, level int) {
 	}
 }
 
-func (p *relationalProps) findColumn(name string) *columnProps {
+func (p *relationalProps) findColumn(name columnName) *columnProps {
 	for i := range p.columns {
 		col := &p.columns[i]
 		if col.name == name {

--- a/v3/stats.go
+++ b/v3/stats.go
@@ -56,7 +56,7 @@ func (h *histogram) String() string {
 // and no buckets.
 func createHistogram(
 	catalog map[tableName]*table,
-	tblName tableName, colName string,
+	tblName tableName, colName columnName,
 	rows *tree.Select,
 ) *histogram {
 	values, ok := rows.Select.(*tree.ValuesClause)

--- a/v3/stats.go
+++ b/v3/stats.go
@@ -55,8 +55,8 @@ func (h *histogram) String() string {
 // This creates a histogram with rowCount=1000, distinctCount=100, nullCount=10
 // and no buckets.
 func createHistogram(
-	catalog map[string]*table,
-	tableName, colName string,
+	catalog map[tableName]*table,
+	tblName tableName, colName string,
 	rows *tree.Select,
 ) *histogram {
 	values, ok := rows.Select.(*tree.ValuesClause)
@@ -64,14 +64,14 @@ func createHistogram(
 		fatalf("unsupported rows: %s", rows)
 	}
 
-	tab, ok := catalog[tableName]
+	tab, ok := catalog[tblName]
 	if !ok {
-		fatalf("unable to find table %s", tableName)
+		fatalf("unable to find table %s", tblName)
 	}
 
 	colIdx, ok := tab.colMap[colName]
 	if !ok {
-		fatalf("unable to find %s.%s", tableName, colName)
+		fatalf("unable to find %s.%s", tblName, colName)
 	}
 
 	col := &tab.columns[colIdx]

--- a/v3/table.go
+++ b/v3/table.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+type tableName string
+
 type column struct {
 	name    string
 	notNull bool
@@ -40,13 +42,13 @@ func (k *tableKey) equalColumns(other tableKey) bool {
 }
 
 type table struct {
-	name    string
+	name    tableName
 	colMap  map[string]int
 	columns []column
 	keys    []tableKey
 }
 
-func createTable(catalog map[string]*table, stmt *tree.CreateTable) *table {
+func createTable(catalog map[tableName]*table, stmt *tree.CreateTable) *table {
 	getKey := func(t *table, key tableKey) *tableKey {
 		for i := range t.keys {
 			if t.keys[i].equalColumns(key) {
@@ -99,11 +101,11 @@ func createTable(catalog map[string]*table, stmt *tree.CreateTable) *table {
 		return res
 	}
 
-	tableName, err := stmt.Table.Normalize()
+	tn, err := stmt.Table.Normalize()
 	if err != nil {
 		fatalf("%s", err)
 	}
-	name := tableName.Table()
+	name := tableName(tn.Table())
 	if _, ok := catalog[name]; ok {
 		fatalf("table %s already exists", name)
 	}
@@ -146,7 +148,7 @@ func createTable(catalog map[string]*table, stmt *tree.CreateTable) *table {
 				if err != nil {
 					fatalf("%s", err)
 				}
-				refName := refTable.Table()
+				refName := tableName(refTable.Table())
 				ref, ok := catalog[refName]
 				if !ok {
 					fatalf("unable to find referenced table %s", refTable)
@@ -201,7 +203,7 @@ func createTable(catalog map[string]*table, stmt *tree.CreateTable) *table {
 			if err != nil {
 				fatalf("%s", err)
 			}
-			refName := refTable.Table()
+			refName := tableName(refTable.Table())
 			ref, ok := catalog[refName]
 			if !ok {
 				fatalf("unable to find referenced table %s", refTable)


### PR DESCRIPTION
#### use tableName type instead of string

We have a bunch of places where we're using a string (e.g. as a map key) and
it's not immediately obvious what the string is. This commit adds a new type for
table names.

#### add columnName type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/32)
<!-- Reviewable:end -->
