### PR TITLE
Make pass through orderings more explicit

### DIFF
--- a/v3/TODO
+++ b/v3/TODO
@@ -12,6 +12,11 @@ Cost
 Memo
 ----
 
+- For operators with physical properties, have `memo.String()` display
+  the child location (not group) they point to. For example, `[sort
+  <+1> [7]]` should be `[sort <+1> [7.1]` and `[select <+1> [5 2]]`
+  should be `[select <+1> [5.3 2]]`.
+
 - Cache scalar expressions that do not contain subqueries.
 
 - Figure out a way to reuse the cursor memory. One challenge is that

--- a/v3/testdata/order
+++ b/v3/testdata/order
@@ -52,14 +52,14 @@ index-scan [out=(0-2)]
 prep,memo,search
 SELECT y FROM a ORDER BY x
 ----
-3: [project [1 2]] [sort <+0> [3]]
+3: [project [1 2]] [project <+0> [1 2]] [sort <+0> [3]]
 2: [variable a.y]
 1: [scan a] [index-scan a@primary <+0> [-]] [index-scan a@y_idx <+1> [-]] [sort <+0> [1]]
 
 prep,memo,search
 SELECT y FROM a ORDER BY y
 ----
-3: [project [1 2]] [sort <+1> [3]]
+3: [project [1 2]] [project <+1> [1 2]] [sort <+1> [3]]
 2: [variable a.y]
 1: [scan a] [index-scan a@primary <+0> [-]] [index-scan a@y_idx <+1> [-]] [sort <+1> [1]]
 
@@ -68,6 +68,7 @@ SELECT y FROM a ORDER BY y
 ----
 project [out=(1)]
   columns: a.y:1
+  ordering: +1
   projections:
     variable (a.y) [in=(1)]
   inputs:
@@ -100,8 +101,8 @@ sort [out=(0-2)]
 prep,memo,search
 SELECT y FROM a WHERE y > 1 ORDER BY y
 ----
-6: [project [5 2]] [sort <+1> [6]]
-5: [select [1 4]] [sort <+1> [5]]
+6: [project [5 2]] [project <+1> [5 2]] [sort <+1> [6]]
+5: [select [1 4]] [select <+1> [1 4]] [sort <+1> [5]]
 4: [gt [2 3]]
 3: [const 1]
 2: [variable a.y]
@@ -112,6 +113,7 @@ SELECT y FROM a WHERE y > 1 ORDER BY y
 ----
 project [out=(1)]
   columns: a.y:1
+  ordering: +1
   projections:
     variable (a.y) [in=(1)]
   inputs:
@@ -119,6 +121,7 @@ project [out=(1)]
       columns: a.x:0 a.y:1* a.z:2
       weak key: (0)
       key: (1)
+      ordering: +1
       filters:
         gt [in=(1)]
           inputs:


### PR DESCRIPTION
For operators which pass through the ordering of their children (select
and project), create a new expression containing the passed through
ordering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/33)
<!-- Reviewable:end -->
