### PR TITLE
Add functions to filter a histogram

### DIFF
--- a/v3/planner.go
+++ b/v3/planner.go
@@ -51,6 +51,8 @@ func (p *planner) exec(stmt tree.Statement) string {
 			p.catalog, tableName(tname.DatabaseName), columnName(tname.TableName), stmt.Rows,
 		)
 		return h.String()
+	case *tree.Select:
+		return filterHistogram(p.catalog, stmt).String()
 	default:
 		unimplemented("%T", stmt)
 	}

--- a/v3/stats.go
+++ b/v3/stats.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 	"sort"
 
+	"go/constant"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 type bucket struct {
-	// The number of values in the bucket.
+	// The number of values in the bucket equal to upperBound.
+	numEq int64
+	// The number of values in the bucket, excluding those that are
+	// equal to upperBound.
 	numRange int64
 	// The upper boundary of the bucket. The column values for the upper bound
 	// are encoded using the ascending key encoding.
@@ -24,6 +29,8 @@ type histogram struct {
 	distinctCount int64
 	// The number of NULL values for the column.
 	nullCount int64
+	// One less than the minimum value of the column.
+	lowerBound tree.Datum
 	// The histogram buckets which describe the distribution of non-NULL
 	// values. The buckets are sorted by bucket.upperBound.
 	buckets []bucket
@@ -31,12 +38,13 @@ type histogram struct {
 
 func (h *histogram) String() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "rows:     %d\n", h.rowCount)
-	fmt.Fprintf(&buf, "distinct: %d\n", h.distinctCount)
-	fmt.Fprintf(&buf, "nulls:    %d\n", h.nullCount)
-	fmt.Fprintf(&buf, "buckets: ")
+	fmt.Fprintf(&buf, "rows:       %d\n", h.rowCount)
+	fmt.Fprintf(&buf, "distinct:   %d\n", h.distinctCount)
+	fmt.Fprintf(&buf, "nulls:      %d\n", h.nullCount)
+	fmt.Fprintf(&buf, "lowerBound: %s\n", h.lowerBound)
+	fmt.Fprintf(&buf, "buckets:   ")
 	for _, b := range h.buckets {
-		fmt.Fprintf(&buf, " %s:%d", b.upperBound, b.numRange)
+		fmt.Fprintf(&buf, " %s:%d,%d", b.upperBound, b.numRange, b.numEq)
 	}
 	buf.WriteString("\n")
 	return buf.String()
@@ -78,7 +86,7 @@ func createHistogram(
 	col.hist = &histogram{}
 
 	for _, v := range values.Tuples {
-		if len(v.Exprs) != 2 {
+		if len(v.Exprs) != 2 && len(v.Exprs) != 3 {
 			fatalf("malformed histogram bucket: %s", v)
 		}
 
@@ -93,7 +101,18 @@ func createHistogram(
 			if err != nil {
 				fatalf("malformed histogram bucket: %s: %v", v, err)
 			}
+
+			// Buckets have 3 values.
+			if len(v.Exprs) != 3 {
+				fatalf("malformed histogram bucket: %s", v)
+			}
+			numEq, err := v.Exprs[2].(*tree.NumVal).AsInt64()
+			if err != nil {
+				fatalf("malformed histogram bucket: %s: %v", v, err)
+			}
+
 			col.hist.buckets = append(col.hist.buckets, bucket{
+				numEq:      numEq,
 				numRange:   val,
 				upperBound: upperBound,
 			})
@@ -105,6 +124,11 @@ func createHistogram(
 				col.hist.distinctCount = val
 			case "nulls":
 				col.hist.nullCount = val
+			case "lowerBound":
+				col.hist.lowerBound, err = v.Exprs[1].(*tree.NumVal).ResolveAsType(nil, types.Int)
+				if err != nil {
+					fatalf("malformed histogram bucket: %s: %v", v, err)
+				}
 			}
 		default:
 			unimplemented("histogram bucket: %T", v.Exprs[0])
@@ -119,4 +143,230 @@ func createHistogram(
 	})
 
 	return col.hist
+}
+
+// filterHistogram filters a histogram based on the WHERE clause in the given select
+// statement, and returns the histogram.  It expects a statement of the form:
+//   SELECT * from histogram.table.column WHERE ...
+// Currently the only operators supported in the WHERE clause are <, <=, >, and >=.
+func filterHistogram(catalog map[tableName]*table, stmt *tree.Select) *histogram {
+	sel, ok := stmt.Select.(*tree.SelectClause)
+	if !ok {
+		unimplemented("%s", stmt)
+	}
+
+	// Get the histogram name.
+	name, ok := sel.From.Tables[0].(*tree.AliasedTableExpr).Expr.(*tree.NormalizableTableName)
+	if !ok {
+		unimplemented("%s", stmt)
+	}
+	tname, err := name.Normalize()
+	if err != nil {
+		fatalf("unable to normalize: %v", err)
+	}
+	if tname.PrefixName != "histogram" {
+		unimplemented("%s", stmt)
+	}
+
+	// Get the histogram from the catalog.
+	tblName, colName := tableName(tname.DatabaseName), columnName(tname.TableName)
+	tab, ok := catalog[tblName]
+	if !ok {
+		fatalf("unable to find table %s", tblName)
+	}
+	colIdx, ok := tab.colMap[colName]
+	if !ok {
+		fatalf("unable to find %s.%s", tblName, colName)
+	}
+	hist := tab.columns[colIdx].hist
+
+	// Filter the histogram.
+	expr, ok := sel.Where.Expr.(*tree.ComparisonExpr)
+	if !ok {
+		unimplemented("%s", stmt)
+	}
+	op := comparisonOpMap[expr.Operator]
+	val, err := expr.Right.(*tree.NumVal).AsInt64()
+	if err != nil {
+		unimplemented("%s", stmt)
+	}
+	switch op {
+	case leOp, ltOp:
+		return hist.filterHistogramLtOpLeOp(op, val)
+	case geOp, gtOp:
+		return hist.filterHistogramGtOpGeOp(op, val)
+	default:
+		unimplemented("%s", stmt)
+	}
+
+	return nil
+}
+
+// newHistogram creates a new histogram given new buckets and a new lower bound,
+// which represent a filtered version of the existing histogram h.
+func (h *histogram) newHistogram(newBuckets []bucket, lowerBound tree.Datum) *histogram {
+	total := int64(0)
+	for _, b := range newBuckets {
+		total += b.numEq + b.numRange
+	}
+
+	selectivity := float64(total) / float64(h.rowCount)
+	return &histogram{
+		rowCount: total,
+
+		// Estimate the new distinctCount based on the selectivity of this filter.
+		// todo(rytaft): this could be more precise if we take into account the
+		// null count of the original histogram.
+		distinctCount: int64(float64(h.distinctCount) * selectivity),
+
+		// All the returned rows will be non-null for this column.
+		nullCount:  0,
+		lowerBound: lowerBound,
+		buckets:    newBuckets,
+	}
+}
+
+// filterHistogramLtOpLeOp applies a filter to the histogram that compares
+// the histogram column value to a constant value with a ltOp or leOp (e.g., x < 4).
+// Returns an updated histogram including only the values that satisfy the predicate.
+func (h *histogram) filterHistogramLtOpLeOp(op operator, val int64) *histogram {
+	if op != ltOp && op != leOp {
+		panic("filterHistogramLtOpLeOp called with operator " + op.String())
+	}
+
+	// NB: The following logic only works for integer valued columns. This will need to
+	// be altered for floating point columns and other types.
+	lowerBound := (int64)(*h.lowerBound.(*tree.DInt))
+	var newBuckets []bucket
+	for _, b := range h.buckets {
+		if val <= lowerBound {
+			break
+		}
+		upperBound := (int64)(*b.upperBound.(*tree.DInt))
+		if val < upperBound {
+			// The bucket size calculation has a -1 because numRange does not
+			// include values equal to upperBound.
+			bucketSize := upperBound - lowerBound - 1
+			if bucketSize > 0 {
+				var bucketMatchSize int64
+				var newUpperBound int64
+				if op == leOp {
+					// The matching values include val for leOp.
+					bucketMatchSize = val - lowerBound
+					newUpperBound = val + 1
+				} else { /* op == ltOp */
+					// The matching values do not include val for ltOp.
+					bucketMatchSize = val - lowerBound - 1
+					newUpperBound = val
+				}
+
+				// Create the new bucket.
+				buc := bucket{
+					numEq: 0,
+					// Assuming a uniform distribution.
+					numRange: (int64)(float64(b.numRange) * float64(bucketMatchSize) / float64(bucketSize)),
+				}
+				v := &tree.NumVal{Value: constant.MakeInt64(newUpperBound)}
+				var err error
+				buc.upperBound, err = v.ResolveAsType(nil, types.Int)
+				if err != nil {
+					fatalf("malformed histogram bucket: %s: %v", v, err)
+				}
+				newBuckets = append(newBuckets, buc)
+			}
+			break
+		}
+		if val == upperBound {
+			buc := b
+			if op == ltOp {
+				buc.numEq = 0
+			}
+			newBuckets = append(newBuckets, buc)
+			break
+		}
+
+		newBuckets = append(newBuckets, b)
+		lowerBound = upperBound
+	}
+
+	return h.newHistogram(newBuckets, h.lowerBound)
+}
+
+// filterHistogramGtOpGeOp applies a filter to the histogram that compares
+// the histogram column value to a constant value with a gtOp or geOp (e.g., x > 4).
+// Returns an updated histogram including only the values that satisfy the predicate.
+func (h *histogram) filterHistogramGtOpGeOp(op operator, val int64) *histogram {
+	if op != gtOp && op != geOp {
+		panic("filterHistogramGtOpGeOp called with operator " + op.String())
+	}
+
+	// NB: The following logic only works for integer valued columns. This will need to
+	// be altered for floating point columns and other types.
+	var newBuckets []bucket
+	for i := len(h.buckets) - 1; i >= 0; i-- {
+		b := h.buckets[i]
+		upperBound := (int64)(*b.upperBound.(*tree.DInt))
+		if val > upperBound {
+			break
+		}
+		if val == upperBound {
+			if op == geOp {
+				buc := b
+				buc.numRange = 0
+				newBuckets = append(newBuckets, buc)
+			}
+			break
+		}
+
+		var lowerBound int64
+		if i == 0 {
+			lowerBound = (int64)(*h.lowerBound.(*tree.DInt))
+		} else {
+			lowerBound = (int64)(*h.buckets[i-1].upperBound.(*tree.DInt))
+		}
+		if val > lowerBound {
+			// The bucket size calculation has a -1 because numRange does not
+			// include values equal to upperBound.
+			bucketSize := upperBound - lowerBound - 1
+			numRange := int64(0)
+			if bucketSize > 0 {
+				var bucketMatchSize int64
+				if op == geOp {
+					// The matching values include val for geOp.
+					bucketMatchSize = upperBound - val
+				} else { /* op == gtOp */
+					// The matching values do not include val for gtOp.
+					bucketMatchSize = upperBound - val - 1
+				}
+
+				// Assuming a uniform distribution.
+				numRange = (int64)(float64(b.numRange) * float64(bucketMatchSize) / float64(bucketSize))
+			}
+			buc := b
+			buc.numRange = numRange
+			newBuckets = append(newBuckets, buc)
+			break
+		}
+
+		newBuckets = append(newBuckets, b)
+	}
+
+	// Reverse the buckets so they are sorted in ascending order.
+	for i, j := 0, len(newBuckets)-1; i < j; i, j = i+1, j-1 {
+		newBuckets[i], newBuckets[j] = newBuckets[j], newBuckets[i]
+	}
+
+	// Find the new lower bound of the histogram.
+	var newLowerBound int64
+	if op == geOp {
+		newLowerBound = val - 1
+	} else { /* op == gtOp */
+		newLowerBound = val
+	}
+	v := &tree.NumVal{Value: constant.MakeInt64(newLowerBound)}
+	lb, err := v.ResolveAsType(nil, types.Int)
+	if err != nil {
+		fatalf("could not create lower bound Datum: %s: %v", v, err)
+	}
+	return h.newHistogram(newBuckets, lb)
 }

--- a/v3/testdata/stats
+++ b/v3/testdata/stats
@@ -10,9 +10,83 @@ INSERT INTO histogram.a.x VALUES
   ('rows', 1000),
   ('distinct', 100),
   ('nulls', 10),
-  (4, 5), (2, 3), (6, 7)
+  ('lowerBound', 0),
+  (4, 5, 2), (2, 3, 3), (100, 976, 1)
 ----
-rows:     1000
-distinct: 100
-nulls:    10
-buckets:  2:3 4:5 6:7
+rows:       1000
+distinct:   100
+nulls:      10
+lowerBound: 0
+buckets:    2:3,3 4:5,2 100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x < 4
+----
+rows:       11
+distinct:   1
+nulls:      0
+lowerBound: 0
+buckets:    2:3,3 4:5,0
+
+exec
+SELECT * FROM histogram.a.x WHERE x <= 4
+----
+rows:       13
+distinct:   1
+nulls:      0
+lowerBound: 0
+buckets:    2:3,3 4:5,2
+
+exec
+SELECT * FROM histogram.a.x WHERE x > 4
+----
+rows:       977
+distinct:   97
+nulls:      0
+lowerBound: 4
+buckets:    100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x >= 4
+----
+rows:       979
+distinct:   97
+nulls:      0
+lowerBound: 3
+buckets:    4:0,2 100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x < 50
+----
+rows:       475
+distinct:   47
+nulls:      0
+lowerBound: 0
+buckets:    2:3,3 4:5,2 50:462,0
+
+exec
+SELECT * FROM histogram.a.x WHERE x <= 50
+----
+rows:       485
+distinct:   48
+nulls:      0
+lowerBound: 0
+buckets:    2:3,3 4:5,2 51:472,0
+
+exec
+SELECT * FROM histogram.a.x WHERE x > 50
+----
+rows:       504
+distinct:   50
+nulls:      0
+lowerBound: 50
+buckets:    100:503,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x >= 50
+----
+rows:       514
+distinct:   51
+nulls:      0
+lowerBound: 49
+buckets:    100:513,1


### PR DESCRIPTION
Add functions to filter a histogram given a predicate such as
x < 4, in which the column is compared to a constant with a
scalar operator.  The new functions filter the histogram for
the operators ltOp, leOp, gtOp and geOp. The result is a histogram
which essentially has a subset of the buckets in the original
histogram. There is some complexity if the constant in the predicate
falls in the middle of a bucket, because then the bucket
must be split into two buckets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/35)
<!-- Reviewable:end -->
