### PR TITLE
Simplify scalarProps

### DIFF
--- a/v3/build.go
+++ b/v3/build.go
@@ -582,7 +582,6 @@ func buildProjections(
 				if name == "" {
 					name = columnName(fmt.Sprintf("column%d", len(result.props.columns)+1))
 				}
-				p.scalarProps.definedCols.Add(index)
 				result.props.columns = append(result.props.columns, columnProps{
 					index: index,
 					name:  name,

--- a/v3/push_down.go
+++ b/v3/push_down.go
@@ -120,8 +120,12 @@ func pushDownFiltersSelectProject(e *expr) {
 
 		// Failed to push the filter as-is, so try to create a new filter using one
 		// of the projection expressions.
-		for _, project := range input.projections() {
-			if filter.scalarInputCols().Equals(project.scalarProps.definedCols) {
+		for i, project := range input.projections() {
+			// The order of the projections maps precisely to the order of the output
+			// columns.
+			col := &input.props.columns[i]
+			inputCols := filter.scalarInputCols()
+			if inputCols.Contains(col.index) {
 				newFilter := substitute(filter, filter.scalarInputCols(), project)
 				if newFilter.scalarInputCols().SubsetOf(projectInput.props.availableOutputCols()) {
 					pushFilter(projectInput, newFilter)

--- a/v3/scalar_props.go
+++ b/v3/scalar_props.go
@@ -1,12 +1,6 @@
 package v3
 
 type scalarProps struct {
-	// Columns defined by the scalar expression.
-	definedCols bitmap
-
 	// Columns used by the scalar expression.
 	inputCols bitmap
-
-	// Does the scalar expression contain a subquery.
-	containsSubquery bool
 }


### PR DESCRIPTION
Remove definedCols which was only needed for projections, but that info
was also available in relationalProps.columns. Remove containsSubquery
which was never used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/36)
<!-- Reviewable:end -->
