### PR TITLE
Every scan generates a new set of output cols

### DIFF
--- a/v3/relational_props.go
+++ b/v3/relational_props.go
@@ -13,6 +13,10 @@ type queryState struct {
 	catalog map[tableName]*table
 	// map from table name to the column index for the table's columns within the
 	// query (they form a contiguous group starting at this index).
+	//
+	// TODO(peter): This is used to lookup tables for foreign keys, but such
+	// lookups need to be scoped. Or the handling of foreign keys needs to be
+	// rethought.
 	tables map[tableName]bitmapIndex
 	// nextVar keeps track of the next index for a column (used during build).
 	nextVar bitmapIndex

--- a/v3/testdata/build
+++ b/v3/testdata/build
@@ -369,14 +369,14 @@ union [out=(0,1)]
   inputs:
     scan [out=(0,1)]
       columns: a.x:0 a.y:1
-    project [out=(0,1)]
-      columns: a.y:1 a.x:0
+    project [out=(2,3)]
+      columns: a.y:3 a.x:2
       projections:
-        variable (a.y) [in=(1)]
-        variable (a.x) [in=(0)]
+        variable (a.y) [in=(3)]
+        variable (a.x) [in=(2)]
       inputs:
-        scan [out=(0,1)]
-          columns: a.x:0 a.y:1
+        scan [out=(2,3)]
+          columns: a.x:2 a.y:3
 
 build
 SELECT b.x FROM a NATURAL JOIN b NATURAL JOIN c

--- a/v3/testdata/push_down
+++ b/v3/testdata/push_down
@@ -199,3 +199,36 @@ inner-join [out=(0-5)]
       inputs:
         scan [out=(4,5)]
           columns: c.x:4 c.w:5
+
+prep
+SELECT * FROM a AS l JOIN a AS r ON (l.x = r.y)
+----
+inner-join [out=(0-3)]
+  columns: l.x:0* l.y:1 r.x:2 r.y:3*
+  equiv: (0,3)
+  filters:
+    eq [in=(0,3)]
+      inputs:
+        variable (l.x) [in=(0)]
+        variable (r.y) [in=(3)]
+  inputs:
+    select [out=(0,1)]
+      columns: l.x:0* l.y:1
+      filters:
+        IS-NOT [in=(0)]
+          inputs:
+            variable (l.x) [in=(0)]
+            const (NULL)
+      inputs:
+        scan [out=(0,1)]
+          columns: l.x:0 l.y:1
+    select [out=(2,3)]
+      columns: r.x:2 r.y:3*
+      filters:
+        IS-NOT [in=(3)]
+          inputs:
+            variable (r.y) [in=(3)]
+            const (NULL)
+      inputs:
+        scan [out=(2,3)]
+          columns: r.x:2 r.y:3


### PR DESCRIPTION
Previously, the output cols for a scan of a table were the same for
every time the table was referenced in a query. But that causes badness
for pushing down filters in self-joins such as:

  SELECT * FROM a AS l JOIN a AS r ON (l.x = r.y)

For this query, `l.x` is not equivalent to `r.x` and `l.y` is not
equivalent to `r.y`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/38)
<!-- Reviewable:end -->
