### PR TITLE
Fix pushDownFilters to maintain the outputCols property

### DIFF
--- a/v3/prep.go
+++ b/v3/prep.go
@@ -10,8 +10,6 @@ func prep(e *expr) *physicalProps {
 	normalize(e)
 	inferFilters(e)
 	pushDownFilters(e)
-	// TODO(peter): pushing down filters adjusts the output columns.
-	trimOutputCols(e, e.props.outputCols)
 	xformApplyAll(joinElimination{}, e)
 	return required
 }


### PR DESCRIPTION
Remove the hack to perform outputCols propagation after pushing down
filters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/40)
<!-- Reviewable:end -->
