### PR TITLE
rename operatorInfo and related names

### DIFF
--- a/v3/apply.go
+++ b/v3/apply.go
@@ -40,10 +40,10 @@ func init() {
 	}
 
 	// TODO(peter): using the join operator here is a temporary hack.
-	registerOperator(innerJoinApplyOp, "inner-join (apply)", join{})
-	registerOperator(leftJoinApplyOp, "left-join (apply)", join{})
-	registerOperator(rightJoinApplyOp, "right-join (apply)", join{})
-	registerOperator(fullJoinApplyOp, "full-join (apply)", join{})
-	registerOperator(semiJoinApplyOp, "semi-join (apply)", join{})
-	registerOperator(antiJoinApplyOp, "anti-join (apply)", join{})
+	registerOperator(innerJoinApplyOp, "inner-join (apply)", joinClass{})
+	registerOperator(leftJoinApplyOp, "left-join (apply)", joinClass{})
+	registerOperator(rightJoinApplyOp, "right-join (apply)", joinClass{})
+	registerOperator(fullJoinApplyOp, "full-join (apply)", joinClass{})
+	registerOperator(semiJoinApplyOp, "semi-join (apply)", joinClass{})
+	registerOperator(antiJoinApplyOp, "anti-join (apply)", joinClass{})
 }

--- a/v3/expr.go
+++ b/v3/expr.go
@@ -329,11 +329,11 @@ func (e *expr) isScalar() bool {
 }
 
 func (e *expr) layout() exprLayout {
-	return operatorLayout[e.op]
+	return operatorTab[e.op].layout
 }
 
 func (e *expr) opClass() operatorClass {
-	return operatorTab[e.op]
+	return operatorTab[e.op].class
 }
 
 func (e *expr) initKeys(state *queryState) {

--- a/v3/expr.go
+++ b/v3/expr.go
@@ -113,7 +113,7 @@ func (e *expr) MemoString() string {
 }
 
 func (e *expr) format(tp *treePrinter) {
-	e.info().format(e, tp)
+	e.opClass().format(e, tp)
 }
 
 func formatRelational(e *expr, tp *treePrinter) {
@@ -313,42 +313,42 @@ func (e *expr) hasApply() bool {
 }
 
 func (e *expr) isLogical() bool {
-	return (e.info().kind() & logicalKind) != 0
+	return (e.opClass().kind() & logicalKind) != 0
 }
 
 func (e *expr) isPhysical() bool {
-	return (e.info().kind() & physicalKind) != 0
+	return (e.opClass().kind() & physicalKind) != 0
 }
 
 func (e *expr) isRelational() bool {
-	return (e.info().kind() & relationalKind) != 0
+	return (e.opClass().kind() & relationalKind) != 0
 }
 
 func (e *expr) isScalar() bool {
-	return (e.info().kind() & scalarKind) != 0
+	return (e.opClass().kind() & scalarKind) != 0
 }
 
 func (e *expr) layout() exprLayout {
 	return operatorLayout[e.op]
 }
 
-func (e *expr) info() operatorInfo {
+func (e *expr) opClass() operatorClass {
 	return operatorTab[e.op]
 }
 
 func (e *expr) initKeys(state *queryState) {
-	e.info().initKeys(e, state)
+	e.opClass().initKeys(e, state)
 }
 
 func (e *expr) initProps() {
 	if e.props != nil {
 		e.props.init()
 	}
-	e.info().updateProps(e)
+	e.opClass().updateProps(e)
 }
 
 func (e *expr) updateProps() {
-	e.info().updateProps(e)
+	e.opClass().updateProps(e)
 }
 
 func (e *expr) scalarInputCols() bitmap {

--- a/v3/group.go
+++ b/v3/group.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(groupByOp, "group-by", groupBy{})
+	registerOperator(groupByOp, "group-by", groupByClass{})
 }
 
 func newGroupByExpr(input *expr) *expr {
@@ -11,20 +11,22 @@ func newGroupByExpr(input *expr) *expr {
 	}
 }
 
-type groupBy struct{}
+type groupByClass struct{}
 
-func (groupBy) kind() operatorKind {
+var _ operatorClass = groupByClass{}
+
+func (groupByClass) kind() operatorKind {
 	return logicalKind | relationalKind
 }
 
-func (groupBy) layout() exprLayout {
+func (groupByClass) layout() exprLayout {
 	return exprLayout{
 		groupings:    1,
 		aggregations: 2,
 	}
 }
 
-func (groupBy) format(e *expr, tp *treePrinter) {
+func (groupByClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "groupings", e.groupings())
@@ -33,10 +35,10 @@ func (groupBy) format(e *expr, tp *treePrinter) {
 	tp.Exit()
 }
 
-func (groupBy) initKeys(e *expr, state *queryState) {
+func (groupByClass) initKeys(e *expr, state *queryState) {
 }
 
-func (groupBy) updateProps(e *expr) {
+func (groupByClass) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 	e.props.outerCols.DifferenceWith(e.providedInputCols())
 	for _, input := range e.inputs() {
@@ -46,6 +48,6 @@ func (groupBy) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
-func (groupBy) requiredProps(required *physicalProps, child int) *physicalProps {
+func (groupByClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }

--- a/v3/index_scan.go
+++ b/v3/index_scan.go
@@ -5,7 +5,7 @@ import (
 )
 
 func init() {
-	registerOperator(indexScanOp, "index-scan", indexScan{})
+	registerOperator(indexScanOp, "index-scan", indexScanClass{})
 }
 
 func newIndexScanExpr(table *table, key *tableKey, scanProps *relationalProps) *expr {
@@ -51,13 +51,15 @@ func newIndexScanExpr(table *table, key *tableKey, scanProps *relationalProps) *
 	return indexScan
 }
 
-type indexScan struct{}
+type indexScanClass struct{}
 
-func (indexScan) kind() operatorKind {
+var _ operatorClass = indexScanClass{}
+
+func (indexScanClass) kind() operatorKind {
 	return physicalKind | relationalKind
 }
 
-func (indexScan) layout() exprLayout {
+func (indexScanClass) layout() exprLayout {
 	return exprLayout{
 		numAux:       1,
 		aggregations: -1,
@@ -67,18 +69,18 @@ func (indexScan) layout() exprLayout {
 	}
 }
 
-func (indexScan) format(e *expr, tp *treePrinter) {
+func (indexScanClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	formatExprs(tp, "projections", e.projections())
 }
 
-func (indexScan) initKeys(e *expr, state *queryState) {
+func (indexScanClass) initKeys(e *expr, state *queryState) {
 }
 
-func (indexScan) updateProps(e *expr) {
+func (indexScanClass) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 }
 
-func (indexScan) requiredProps(required *physicalProps, child int) *physicalProps {
+func (indexScanClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }

--- a/v3/join.go
+++ b/v3/join.go
@@ -1,12 +1,12 @@
 package v3
 
 func init() {
-	registerOperator(innerJoinOp, "inner-join", join{})
-	registerOperator(leftJoinOp, "left-join", join{})
-	registerOperator(rightJoinOp, "right-join", join{})
-	registerOperator(fullJoinOp, "full-join", join{})
-	registerOperator(semiJoinOp, "semi-join", join{})
-	registerOperator(antiJoinOp, "anti-join", join{})
+	registerOperator(innerJoinOp, "inner-join", joinClass{})
+	registerOperator(leftJoinOp, "left-join", joinClass{})
+	registerOperator(rightJoinOp, "right-join", joinClass{})
+	registerOperator(fullJoinOp, "full-join", joinClass{})
+	registerOperator(semiJoinOp, "semi-join", joinClass{})
+	registerOperator(antiJoinOp, "anti-join", joinClass{})
 }
 
 func newJoinExpr(op operator, left, right *expr) *expr {
@@ -16,19 +16,21 @@ func newJoinExpr(op operator, left, right *expr) *expr {
 	}
 }
 
-type join struct{}
+type joinClass struct{}
 
-func (join) kind() operatorKind {
+var _ operatorClass = joinClass{}
+
+func (joinClass) kind() operatorKind {
 	return logicalKind | relationalKind
 }
 
-func (join) layout() exprLayout {
+func (joinClass) layout() exprLayout {
 	return exprLayout{
 		filters: 2,
 	}
 }
 
-func (join) format(e *expr, tp *treePrinter) {
+func (joinClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "filters", e.filters())
@@ -36,10 +38,10 @@ func (join) format(e *expr, tp *treePrinter) {
 	tp.Exit()
 }
 
-func (join) initKeys(e *expr, state *queryState) {
+func (joinClass) initKeys(e *expr, state *queryState) {
 }
 
-func (join) updateProps(e *expr) {
+func (joinClass) updateProps(e *expr) {
 	e.props.notNullCols = bitmap{}
 	for _, input := range e.inputs() {
 		e.props.notNullCols.UnionWith(input.props.notNullCols)
@@ -57,7 +59,7 @@ func (join) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
-func (join) requiredProps(required *physicalProps, child int) *physicalProps {
+func (joinClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }
 

--- a/v3/memo.go
+++ b/v3/memo.go
@@ -183,7 +183,7 @@ func (e *memoExpr) commonFingerprint(m *memo, physicalProps int32) memoExprFinge
 }
 
 func (e *memoExpr) opClass() operatorClass {
-	return operatorTab[e.op]
+	return operatorTab[e.op].class
 }
 
 // memoOptState maintains the optimization state for a group for a particular

--- a/v3/memo.go
+++ b/v3/memo.go
@@ -182,7 +182,7 @@ func (e *memoExpr) commonFingerprint(m *memo, physicalProps int32) memoExprFinge
 	return f
 }
 
-func (e *memoExpr) info() operatorInfo {
+func (e *memoExpr) opClass() operatorClass {
 	return operatorTab[e.op]
 }
 

--- a/v3/operator.go
+++ b/v3/operator.go
@@ -131,26 +131,26 @@ type operatorClass interface {
 	requiredProps(required *physicalProps, child int) *physicalProps
 }
 
-var (
-	operatorTab = [numOperators]operatorClass{}
+type operatorInfo struct {
+	name   string
+	class  operatorClass
+	layout exprLayout
+}
 
-	operatorLayout = [numOperators]exprLayout{}
-
-	operatorNames = [numOperators]string{
-		unknownOp: "unknown",
-	}
-)
+var operatorTab = [numOperators]operatorInfo{
+	unknownOp: operatorInfo{name: "unknown"},
+}
 
 func (op operator) String() string {
-	if op < 0 || op > operator(len(operatorNames)-1) {
+	if op < 0 || op >= numOperators {
 		return fmt.Sprintf("operator(%d)", op)
 	}
-	return operatorNames[op]
+	return operatorTab[op].name
 }
 
 func registerOperator(op operator, name string, class operatorClass) {
-	operatorNames[op] = name
-	operatorTab[op] = class
+	operatorTab[op].name = name
+	operatorTab[op].class = class
 
 	if class != nil {
 		// Normalize the layout so that auxiliary expressions that are not present
@@ -178,6 +178,6 @@ func registerOperator(op operator, name string, class operatorClass) {
 				l.numAux++
 			}
 		}
-		operatorLayout[op] = l
+		operatorTab[op].layout = l
 	}
 }

--- a/v3/operator.go
+++ b/v3/operator.go
@@ -112,7 +112,7 @@ const (
 	scalarKind
 )
 
-type operatorInfo interface {
+type operatorClass interface {
 	kind() operatorKind
 	format(e *expr, tp *treePrinter)
 
@@ -132,7 +132,7 @@ type operatorInfo interface {
 }
 
 var (
-	operatorTab = [numOperators]operatorInfo{}
+	operatorTab = [numOperators]operatorClass{}
 
 	operatorLayout = [numOperators]exprLayout{}
 
@@ -148,14 +148,14 @@ func (op operator) String() string {
 	return operatorNames[op]
 }
 
-func registerOperator(op operator, name string, info operatorInfo) {
+func registerOperator(op operator, name string, class operatorClass) {
 	operatorNames[op] = name
-	operatorTab[op] = info
+	operatorTab[op] = class
 
-	if info != nil {
+	if class != nil {
 		// Normalize the layout so that auxiliary expressions that are not present
 		// are given an invalid index which will cause a panic if they are accessed.
-		l := info.layout()
+		l := class.layout()
 		if l.numAux == 0 {
 			if l.aggregations == 0 {
 				l.aggregations = -1

--- a/v3/order.go
+++ b/v3/order.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	registerOperator(orderByOp, "order-by", orderBy{})
+	registerOperator(orderByOp, "order-by", orderByClass{})
 }
 
 func newOrderByExpr(input *expr) *expr {
@@ -16,30 +16,32 @@ func newOrderByExpr(input *expr) *expr {
 	}
 }
 
-type orderBy struct{}
+type orderByClass struct{}
 
-func (orderBy) kind() operatorKind {
+var _ operatorClass = orderByClass{}
+
+func (orderByClass) kind() operatorKind {
 	return logicalKind | relationalKind
 }
 
-func (orderBy) layout() exprLayout {
+func (orderByClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (orderBy) format(e *expr, tp *treePrinter) {
+func (orderByClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "inputs", e.inputs())
 	tp.Exit()
 }
 
-func (orderBy) initKeys(e *expr, state *queryState) {
+func (orderByClass) initKeys(e *expr, state *queryState) {
 }
 
-func (orderBy) updateProps(e *expr) {
+func (orderByClass) updateProps(e *expr) {
 }
 
-func (orderBy) requiredProps(required *physicalProps, child int) *physicalProps {
+func (orderByClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }
 

--- a/v3/project.go
+++ b/v3/project.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(projectOp, "project", project{})
+	registerOperator(projectOp, "project", projectClass{})
 }
 
 func newProjectExpr(input *expr) *expr {
@@ -11,20 +11,22 @@ func newProjectExpr(input *expr) *expr {
 	}
 }
 
-type project struct{}
+type projectClass struct{}
 
-func (project) kind() operatorKind {
+var _ operatorClass = projectClass{}
+
+func (projectClass) kind() operatorKind {
 	// Project is both a logical and a physical operator.
 	return logicalKind | physicalKind | relationalKind
 }
 
-func (project) layout() exprLayout {
+func (projectClass) layout() exprLayout {
 	return exprLayout{
 		projections: 1,
 	}
 }
 
-func (project) format(e *expr, tp *treePrinter) {
+func (projectClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "projections", e.projections())
@@ -32,10 +34,10 @@ func (project) format(e *expr, tp *treePrinter) {
 	tp.Exit()
 }
 
-func (project) initKeys(e *expr, state *queryState) {
+func (projectClass) initKeys(e *expr, state *queryState) {
 }
 
-func (project) updateProps(e *expr) {
+func (projectClass) updateProps(e *expr) {
 	excluded := e.props.outputCols.Union(e.providedInputCols())
 	e.props.outerCols = e.requiredInputCols().Difference(excluded)
 	for _, input := range e.inputs() {
@@ -45,7 +47,7 @@ func (project) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
-func (project) requiredProps(required *physicalProps, child int) *physicalProps {
+func (projectClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	if child == 0 {
 		return required // pass through
 	}

--- a/v3/scalar.go
+++ b/v3/scalar.go
@@ -11,56 +11,56 @@ import (
 const spaces = "                                                                "
 
 func init() {
-	registerOperator(constOp, "const", scalar{})
-	registerOperator(placeholderOp, "placeholder", scalar{})
-	registerOperator(listOp, "list", scalar{})
-	registerOperator(orderedListOp, "ordered-list", scalar{})
-	registerOperator(existsOp, "exists", scalar{})
-	registerOperator(andOp, "AND", scalar{})
-	registerOperator(orOp, "OR", scalar{})
-	registerOperator(notOp, "NOT", scalar{})
-	registerOperator(eqOp, "eq", scalar{})
-	registerOperator(ltOp, "lt", scalar{})
-	registerOperator(gtOp, "gt", scalar{})
-	registerOperator(leOp, "le", scalar{})
-	registerOperator(geOp, "ge", scalar{})
-	registerOperator(neOp, "ne", scalar{})
-	registerOperator(inOp, "IN", scalar{})
-	registerOperator(notInOp, "NOT-IN", scalar{})
-	registerOperator(likeOp, "LIKE", scalar{})
-	registerOperator(notLikeOp, "NOT-LIKE", scalar{})
-	registerOperator(iLikeOp, "ILIKE", scalar{})
-	registerOperator(notILikeOp, "NOT-ILIKE", scalar{})
-	registerOperator(similarToOp, "SIMILAR-TO", scalar{})
-	registerOperator(notSimilarToOp, "NOT-SIMILAR-TO", scalar{})
-	registerOperator(regMatchOp, "regmatch", scalar{})
-	registerOperator(notRegMatchOp, "not-regmatch", scalar{})
-	registerOperator(regIMatchOp, "regimatch", scalar{})
-	registerOperator(notRegIMatchOp, "not-regimatch", scalar{})
-	registerOperator(isDistinctFromOp, "IS-DISTINCT-FROM", scalar{})
-	registerOperator(isNotDistinctFromOp, "IS-NOT-DISTINCT-FROM", scalar{})
-	registerOperator(isOp, "IS", scalar{})
-	registerOperator(isNotOp, "IS-NOT", scalar{})
-	registerOperator(anyOp, "ANY", scalar{})
-	registerOperator(someOp, "SOME", scalar{})
-	registerOperator(allOp, "ALL", scalar{})
-	registerOperator(bitandOp, "bitand", scalar{})
-	registerOperator(bitorOp, "bitor", scalar{})
-	registerOperator(bitxorOp, "bitxor", scalar{})
-	registerOperator(plusOp, "plus", scalar{})
-	registerOperator(minusOp, "minux", scalar{})
-	registerOperator(multOp, "mult", scalar{})
-	registerOperator(divOp, "div", scalar{})
-	registerOperator(floorDivOp, "floor-div", scalar{})
-	registerOperator(modOp, "mod", scalar{})
-	registerOperator(powOp, "pow", scalar{})
-	registerOperator(concatOp, "concat", scalar{})
-	registerOperator(lShiftOp, "lshift", scalar{})
-	registerOperator(rShiftOp, "rshift", scalar{})
-	registerOperator(unaryPlusOp, "unary-plus", scalar{})
-	registerOperator(unaryMinusOp, "unary-minus", scalar{})
-	registerOperator(unaryComplementOp, "complement", scalar{})
-	registerOperator(functionOp, "func", scalar{})
+	registerOperator(constOp, "const", scalarClass{})
+	registerOperator(placeholderOp, "placeholder", scalarClass{})
+	registerOperator(listOp, "list", scalarClass{})
+	registerOperator(orderedListOp, "ordered-list", scalarClass{})
+	registerOperator(existsOp, "exists", scalarClass{})
+	registerOperator(andOp, "AND", scalarClass{})
+	registerOperator(orOp, "OR", scalarClass{})
+	registerOperator(notOp, "NOT", scalarClass{})
+	registerOperator(eqOp, "eq", scalarClass{})
+	registerOperator(ltOp, "lt", scalarClass{})
+	registerOperator(gtOp, "gt", scalarClass{})
+	registerOperator(leOp, "le", scalarClass{})
+	registerOperator(geOp, "ge", scalarClass{})
+	registerOperator(neOp, "ne", scalarClass{})
+	registerOperator(inOp, "IN", scalarClass{})
+	registerOperator(notInOp, "NOT-IN", scalarClass{})
+	registerOperator(likeOp, "LIKE", scalarClass{})
+	registerOperator(notLikeOp, "NOT-LIKE", scalarClass{})
+	registerOperator(iLikeOp, "ILIKE", scalarClass{})
+	registerOperator(notILikeOp, "NOT-ILIKE", scalarClass{})
+	registerOperator(similarToOp, "SIMILAR-TO", scalarClass{})
+	registerOperator(notSimilarToOp, "NOT-SIMILAR-TO", scalarClass{})
+	registerOperator(regMatchOp, "regmatch", scalarClass{})
+	registerOperator(notRegMatchOp, "not-regmatch", scalarClass{})
+	registerOperator(regIMatchOp, "regimatch", scalarClass{})
+	registerOperator(notRegIMatchOp, "not-regimatch", scalarClass{})
+	registerOperator(isDistinctFromOp, "IS-DISTINCT-FROM", scalarClass{})
+	registerOperator(isNotDistinctFromOp, "IS-NOT-DISTINCT-FROM", scalarClass{})
+	registerOperator(isOp, "IS", scalarClass{})
+	registerOperator(isNotOp, "IS-NOT", scalarClass{})
+	registerOperator(anyOp, "ANY", scalarClass{})
+	registerOperator(someOp, "SOME", scalarClass{})
+	registerOperator(allOp, "ALL", scalarClass{})
+	registerOperator(bitandOp, "bitand", scalarClass{})
+	registerOperator(bitorOp, "bitor", scalarClass{})
+	registerOperator(bitxorOp, "bitxor", scalarClass{})
+	registerOperator(plusOp, "plus", scalarClass{})
+	registerOperator(minusOp, "minux", scalarClass{})
+	registerOperator(multOp, "mult", scalarClass{})
+	registerOperator(divOp, "div", scalarClass{})
+	registerOperator(floorDivOp, "floor-div", scalarClass{})
+	registerOperator(modOp, "mod", scalarClass{})
+	registerOperator(powOp, "pow", scalarClass{})
+	registerOperator(concatOp, "concat", scalarClass{})
+	registerOperator(lShiftOp, "lshift", scalarClass{})
+	registerOperator(rShiftOp, "rshift", scalarClass{})
+	registerOperator(unaryPlusOp, "unary-plus", scalarClass{})
+	registerOperator(unaryMinusOp, "unary-minus", scalarClass{})
+	registerOperator(unaryComplementOp, "complement", scalarClass{})
+	registerOperator(functionOp, "func", scalarClass{})
 }
 
 func newConstExpr(private interface{}) *expr {
@@ -102,18 +102,20 @@ func newBinaryExpr(op operator, input1, input2 *expr) *expr {
 	return e
 }
 
-type scalar struct{}
+type scalarClass struct{}
 
-func (scalar) kind() operatorKind {
+var _ operatorClass = scalarClass{}
+
+func (scalarClass) kind() operatorKind {
 	// Scalar is both a logical and a physical operator.
 	return logicalKind | physicalKind | scalarKind
 }
 
-func (scalar) layout() exprLayout {
+func (scalarClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (scalar) format(e *expr, tp *treePrinter) {
+func (scalarClass) format(e *expr, tp *treePrinter) {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%v", e.op)
 	if e.private != nil {
@@ -128,10 +130,10 @@ func (scalar) format(e *expr, tp *treePrinter) {
 	tp.Exit()
 }
 
-func (scalar) initKeys(e *expr, state *queryState) {
+func (scalarClass) initKeys(e *expr, state *queryState) {
 }
 
-func (scalar) updateProps(e *expr) {
+func (scalarClass) updateProps(e *expr) {
 	if e.scalarProps != nil {
 		// For a scalar operation the required input columns is the union of the
 		// input columns of its inputs.
@@ -142,7 +144,7 @@ func (scalar) updateProps(e *expr) {
 	}
 }
 
-func (scalar) requiredProps(required *physicalProps, child int) *physicalProps {
+func (scalarClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }
 

--- a/v3/scan.go
+++ b/v3/scan.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(scanOp, "scan", scan{})
+	registerOperator(scanOp, "scan", scanClass{})
 }
 
 func newScanExpr(tab *table) *expr {
@@ -11,21 +11,23 @@ func newScanExpr(tab *table) *expr {
 	}
 }
 
-type scan struct{}
+type scanClass struct{}
 
-func (scan) kind() operatorKind {
+var _ operatorClass = scanClass{}
+
+func (scanClass) kind() operatorKind {
 	return logicalKind | relationalKind
 }
 
-func (scan) layout() exprLayout {
+func (scanClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (scan) format(e *expr, tp *treePrinter) {
+func (scanClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 }
 
-func (scan) initKeys(e *expr, state *queryState) {
+func (scanClass) initKeys(e *expr, state *queryState) {
 	tab := e.private.(*table)
 	props := e.props
 	props.foreignKeys = nil
@@ -55,10 +57,10 @@ func (scan) initKeys(e *expr, state *queryState) {
 	}
 }
 
-func (scan) updateProps(e *expr) {
+func (scanClass) updateProps(e *expr) {
 	e.props.outerCols = e.requiredInputCols().Difference(e.props.outputCols)
 }
 
-func (scan) requiredProps(required *physicalProps, child int) *physicalProps {
+func (scanClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }

--- a/v3/search.go
+++ b/v3/search.go
@@ -232,7 +232,7 @@ func (s *search) optimizeGroup(loc memoLoc, required *physicalProps, parent *sea
 		t.required = required
 
 		// Optimize children groups.
-		op := e.info()
+		op := e.opClass()
 		for i, c := range e.children(s.memo) {
 			s.optimizeGroupTask(&s.memo.groups[c], op.requiredProps(required, i), t)
 		}
@@ -244,7 +244,7 @@ func (s *search) optimizeGroup(loc memoLoc, required *physicalProps, parent *sea
 func (s *search) optimizeGroupExpr(loc memoLoc, required *physicalProps, parent *searchTask) {
 	g := &s.memo.groups[loc.group]
 	e := &g.exprs[loc.expr]
-	if (e.info().kind() & physicalKind) == 0 {
+	if (e.opClass().kind() & physicalKind) == 0 {
 		// We can only perform optimization on physical operators.
 		return
 	}
@@ -283,7 +283,7 @@ func (s *search) optimizeGroupExpr(loc memoLoc, required *physicalProps, parent 
 				s.optimizeGroupTask(g, required, parent)
 			}
 		default:
-			if (e.info().kind() & relationalKind) != 0 {
+			if (e.opClass().kind() & relationalKind) != 0 {
 				return
 			}
 			// Allow scalar ops to fall through.
@@ -328,7 +328,7 @@ func (s *search) optimizeGroupExpr(loc memoLoc, required *physicalProps, parent 
 	// per-operator cost calculation. Need to add a method to operator and factor
 	// in the incoming cardinality.
 	var cost float32
-	op := e.info()
+	op := e.opClass()
 	children := e.children(s.memo)
 	optChildren := make([]*memoOptState, len(children))
 

--- a/v3/select.go
+++ b/v3/select.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(selectOp, "select", sel{})
+	registerOperator(selectOp, "select", selectClass{})
 }
 
 func newSelectExpr(input *expr) *expr {
@@ -11,20 +11,22 @@ func newSelectExpr(input *expr) *expr {
 	}
 }
 
-type sel struct{}
+type selectClass struct{}
 
-func (sel) kind() operatorKind {
+var _ operatorClass = selectClass{}
+
+func (selectClass) kind() operatorKind {
 	// Select is both a logical and a physical operator.
 	return logicalKind | physicalKind | relationalKind
 }
 
-func (sel) layout() exprLayout {
+func (selectClass) layout() exprLayout {
 	return exprLayout{
 		filters: 1,
 	}
 }
 
-func (sel) format(e *expr, tp *treePrinter) {
+func (selectClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "filters", e.filters())
@@ -32,10 +34,10 @@ func (sel) format(e *expr, tp *treePrinter) {
 	tp.Exit()
 }
 
-func (sel) initKeys(e *expr, state *queryState) {
+func (selectClass) initKeys(e *expr, state *queryState) {
 }
 
-func (sel) updateProps(e *expr) {
+func (selectClass) updateProps(e *expr) {
 	// Select is pass through and requires any input columns that its inputs
 	// require.
 	excluded := e.props.outputCols.Union(e.providedInputCols())
@@ -52,7 +54,7 @@ func (sel) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
-func (sel) requiredProps(required *physicalProps, child int) *physicalProps {
+func (selectClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	if child == 0 {
 		return required // pass through
 	}

--- a/v3/set.go
+++ b/v3/set.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(unionOp, "union", union{})
+	registerOperator(unionOp, "union", unionClass{})
 	registerOperator(intersectOp, "intersect", nil)
 	registerOperator(exceptOp, "except", nil)
 }
@@ -13,27 +13,29 @@ func newSetExpr(op operator, input1, input2 *expr) *expr {
 	}
 }
 
-type union struct{}
+type unionClass struct{}
 
-func (union) kind() operatorKind {
+var _ operatorClass = unionClass{}
+
+func (unionClass) kind() operatorKind {
 	return logicalKind | relationalKind
 }
 
-func (union) layout() exprLayout {
+func (unionClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (union) format(e *expr, tp *treePrinter) {
+func (unionClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "inputs", e.inputs())
 	tp.Exit()
 }
 
-func (union) initKeys(e *expr, state *queryState) {
+func (unionClass) initKeys(e *expr, state *queryState) {
 }
 
-func (union) updateProps(e *expr) {
+func (unionClass) updateProps(e *expr) {
 	// Union is pass through and requires any input columns that its inputs
 	// require.
 	excluded := e.props.outputCols.Union(e.providedInputCols())
@@ -45,6 +47,6 @@ func (union) updateProps(e *expr) {
 	e.props.applyInputs(e.inputs())
 }
 
-func (union) requiredProps(required *physicalProps, child int) *physicalProps {
+func (unionClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }

--- a/v3/sort.go
+++ b/v3/sort.go
@@ -1,33 +1,35 @@
 package v3
 
 func init() {
-	registerOperator(sortOp, "sort", sorter{})
+	registerOperator(sortOp, "sort", sorterClass{})
 }
 
-type sorter struct{}
+type sorterClass struct{}
 
-func (sorter) kind() operatorKind {
+var _ operatorClass = sorterClass{}
+
+func (sorterClass) kind() operatorKind {
 	return physicalKind | relationalKind
 }
 
-func (sorter) layout() exprLayout {
+func (sorterClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (sorter) format(e *expr, tp *treePrinter) {
+func (sorterClass) format(e *expr, tp *treePrinter) {
 	formatRelational(e, tp)
 	tp.Enter()
 	formatExprs(tp, "inputs", e.inputs())
 	tp.Exit()
 }
 
-func (sorter) initKeys(e *expr, state *queryState) {
+func (sorterClass) initKeys(e *expr, state *queryState) {
 }
 
-func (sorter) updateProps(e *expr) {
+func (sorterClass) updateProps(e *expr) {
 }
 
-func (sorter) requiredProps(required *physicalProps, child int) *physicalProps {
+func (sorterClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	// A sort expression enforces ordering and does not require any specific
 	// ordering from its input.
 	return nil

--- a/v3/variable.go
+++ b/v3/variable.go
@@ -1,7 +1,7 @@
 package v3
 
 func init() {
-	registerOperator(variableOp, "variable", variable{})
+	registerOperator(variableOp, "variable", variableClass{})
 }
 
 func newVariableExpr(private interface{}, index bitmapIndex) *expr {
@@ -15,27 +15,29 @@ func newVariableExpr(private interface{}, index bitmapIndex) *expr {
 	return e
 }
 
-type variable struct{}
+type variableClass struct{}
 
-func (variable) kind() operatorKind {
+var _ operatorClass = variableClass{}
+
+func (variableClass) kind() operatorKind {
 	// Variable is both a logical and a physical operator.
 	return logicalKind | physicalKind | scalarKind
 }
 
-func (variable) layout() exprLayout {
+func (variableClass) layout() exprLayout {
 	return exprLayout{}
 }
 
-func (variable) format(e *expr, tp *treePrinter) {
+func (variableClass) format(e *expr, tp *treePrinter) {
 	tp.Addf("%v (%s) [in=%s]", e.op, e.private, e.scalarProps.inputCols)
 }
 
-func (variable) initKeys(e *expr, state *queryState) {
+func (variableClass) initKeys(e *expr, state *queryState) {
 }
 
-func (variable) updateProps(e *expr) {
+func (variableClass) updateProps(e *expr) {
 }
 
-func (variable) requiredProps(required *physicalProps, child int) *physicalProps {
+func (variableClass) requiredProps(required *physicalProps, child int) *physicalProps {
 	return nil
 }


### PR DESCRIPTION
#### rename operatorInfo to operatorClass

#### rename operatorClass implementers

scalar -> scalarClass
join -> joinClass
etc.

#### consolidate operator tables

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/41)
<!-- Reviewable:end -->
