### PR TITLE
Add more functions to filter a histogram

### DIFF
--- a/v3/stats.go
+++ b/v3/stats.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/gogo/protobuf/sortkeys"
 )
 
 type bucket struct {
@@ -22,6 +23,23 @@ type bucket struct {
 	upperBound tree.Datum
 }
 
+// A histogram struct stores statistics for a table column, as well as
+// buckets representing the distribution of non-NULL values.
+//
+// The statistics calculated on the base table will be 100% accurate
+// at the time of collection (except for distinctCount, which is an estimate).
+// Statistics become stale quickly, however, if the table is updated
+// frequently.  This struct does not currently include any estimate of
+// the error due to staleness.
+//
+// For histograms representing intermediate states in the query tree,
+// there is an additional source of error due to lack of information
+// about the distribution of values within each histogram bucket at
+// the base of the query tree. For example, when a bucket is split,
+// we calculate the size of the new buckets by assuming that values are
+// uniformly distributed across the original bucket.  The histogram struct does
+// not currently include any estimate of the error due to data distribution
+// within buckets.
 type histogram struct {
 	// The total number of rows in the table.
 	rowCount int64
@@ -29,10 +47,10 @@ type histogram struct {
 	distinctCount int64
 	// The number of NULL values for the column.
 	nullCount int64
-	// One less than the minimum value of the column.
-	lowerBound tree.Datum
 	// The histogram buckets which describe the distribution of non-NULL
 	// values. The buckets are sorted by bucket.upperBound.
+	// The first bucket must have numRange = 0, so the upperBound
+	// of the bucket indicates the lower bound of the histogram.
 	buckets []bucket
 }
 
@@ -41,8 +59,10 @@ func (h *histogram) String() string {
 	fmt.Fprintf(&buf, "rows:       %d\n", h.rowCount)
 	fmt.Fprintf(&buf, "distinct:   %d\n", h.distinctCount)
 	fmt.Fprintf(&buf, "nulls:      %d\n", h.nullCount)
-	fmt.Fprintf(&buf, "lowerBound: %s\n", h.lowerBound)
 	fmt.Fprintf(&buf, "buckets:   ")
+	if len(h.buckets) == 0 {
+		fmt.Fprintf(&buf, " none")
+	}
 	for _, b := range h.buckets {
 		fmt.Fprintf(&buf, " %s:%d,%d", b.upperBound, b.numRange, b.numEq)
 	}
@@ -124,11 +144,6 @@ func createHistogram(
 				col.hist.distinctCount = val
 			case "nulls":
 				col.hist.nullCount = val
-			case "lowerBound":
-				col.hist.lowerBound, err = v.Exprs[1].(*tree.NumVal).ResolveAsType(nil, types.Int)
-				if err != nil {
-					fatalf("malformed histogram bucket: %s: %v", v, err)
-				}
 			}
 		default:
 			unimplemented("histogram bucket: %T", v.Exprs[0])
@@ -141,6 +156,8 @@ func createHistogram(
 		bj := &col.hist.buckets[j]
 		return bi.upperBound.Compare(nil, bj.upperBound) < 0
 	})
+
+	checkBucketsValid(col.hist.buckets)
 
 	return col.hist
 }
@@ -186,15 +203,40 @@ func filterHistogram(catalog map[tableName]*table, stmt *tree.Select) *histogram
 		unimplemented("%s", stmt)
 	}
 	op := comparisonOpMap[expr.Operator]
-	val, err := expr.Right.(*tree.NumVal).AsInt64()
-	if err != nil {
-		unimplemented("%s", stmt)
+	var val int64
+	var vals []int64
+	switch v := expr.Right.(type) {
+	case *tree.NumVal:
+		val, err = v.AsInt64()
+		if err != nil {
+			fatalf("unable to cast datum to int64: %v", err)
+		}
+		vals = []int64{val}
+	case *tree.Tuple:
+		for _, elem := range v.Exprs {
+			numVal, ok := elem.(*tree.NumVal)
+			if !ok {
+				unimplemented("%s", stmt)
+			}
+			val, err = numVal.AsInt64()
+			if err != nil {
+				fatalf("unable to cast datum to int64: %v", err)
+			}
+			vals = append(vals, val)
+		}
+	default:
+		unimplemented("%T", v)
 	}
+
 	switch op {
-	case leOp, ltOp:
+	case ltOp, leOp:
 		return hist.filterHistogramLtOpLeOp(op, val)
-	case geOp, gtOp:
+	case gtOp, geOp:
 		return hist.filterHistogramGtOpGeOp(op, val)
+	case eqOp, inOp:
+		return hist.filterHistogramEqOpInOp(vals)
+	case neOp, notInOp:
+		return hist.filterHistogramNeOpNotInOp(vals)
 	default:
 		unimplemented("%s", stmt)
 	}
@@ -202,82 +244,180 @@ func filterHistogram(catalog map[tableName]*table, stmt *tree.Select) *histogram
 	return nil
 }
 
-// newHistogram creates a new histogram given new buckets and a new lower bound,
-// which represent a filtered version of the existing histogram h.
-func (h *histogram) newHistogram(newBuckets []bucket, lowerBound tree.Datum) *histogram {
+func makeDatum(val int64) tree.Datum {
+	v := &tree.NumVal{Value: constant.MakeInt64(val)}
+	datum, err := v.ResolveAsType(nil, types.Int)
+	if err != nil {
+		fatalf("could not create Datum: %s: %v", v, err)
+	}
+
+	return datum
+}
+
+func newBucket(upperBound, numRange, numEq int64) bucket {
+	return bucket{
+		numEq:      numEq,
+		numRange:   numRange,
+		upperBound: makeDatum(upperBound),
+	}
+}
+
+// splitBucket splits a bucket into two buckets at the given split point.
+// The lower bucket contains the values less than or equal to splitPoint, and the
+// upper bucket contains the values greater than splitPoint. The count of values
+// in numRange is split between the two buckets assuming a uniform distribution.
+//
+// lowerBound  is an exclusive lower bound on the bucket (it's equal to one less
+// than the minimum value).
+func (b bucket) splitBucket(splitPoint, lowerBound int64) (bucket, bucket) {
+	upperBound := (int64)(*b.upperBound.(*tree.DInt))
+
+	// The bucket size calculation has a -1 because numRange does not
+	// include values equal to upperBound.
+	bucketSize := upperBound - lowerBound - 1
+	if bucketSize <= 0 {
+		panic("empty bucket should have been skipped")
+	}
+
+	if splitPoint >= upperBound || splitPoint <= lowerBound {
+		panic(fmt.Sprintf("splitPoint (%d) must be between upperBound (%d) and lowerBound (%d)",
+			splitPoint, upperBound, lowerBound))
+	}
+
+	// Make the lower bucket.
+	lowerMatchSize := splitPoint - lowerBound - 1
+	lowerNumRange := (int64)(float64(b.numRange) * float64(lowerMatchSize) / float64(bucketSize))
+	lowerNumEq := (int64)(float64(b.numRange) / float64(bucketSize))
+	bucLower := newBucket(splitPoint, lowerNumRange, lowerNumEq)
+
+	// Make the upper bucket.
+	upperMatchSize := upperBound - splitPoint - 1
+	bucUpper := b
+	bucUpper.numRange = (int64)(float64(b.numRange) * float64(upperMatchSize) / float64(bucketSize))
+
+	return bucLower, bucUpper
+}
+
+// checkBucketsValid checks that the given buckets
+// are valid histogram buckets, and panics if they are not valid.
+func checkBucketsValid(buckets []bucket) {
+	if len(buckets) == 0 {
+		return
+	}
+
+	if buckets[0].numRange != 0 {
+		panic("First bucket must have numRange = 0")
+	}
+
+	prev := buckets[0].upperBound
+	for i := 1; i < len(buckets); i++ {
+		cur := buckets[i].upperBound
+		if prev.Compare(nil /* ctx */, cur) >= 0 {
+			panic("Buckets must be disjoint and ordered by upperBound")
+		}
+		prev = cur
+	}
+}
+
+// getLowerBound gets the exclusive lower bound on the
+// histogram. i.e., it returns one less than the minimum value
+// in the histogram.
+//
+// It panics if the histogram is empty or if numRange is not
+// zero in the first bucket.
+func (h *histogram) getLowerBound() int64 {
+	if len(h.buckets) == 0 {
+		panic("Called getLowerBound on empty histogram")
+	}
+
+	if h.buckets[0].numRange != 0 {
+		panic("First bucket must have numRange = 0")
+	}
+
+	return (int64)(*h.buckets[0].upperBound.(*tree.DInt)) - 1
+}
+
+// getUpperBound gets the inclusive upper bound on the
+// histogram. i.e., it returns the maximum value
+// in the histogram.
+//
+// It panics if the histogram is empty.
+func (h *histogram) getUpperBound() int64 {
+	if len(h.buckets) == 0 {
+		panic("Called getUpperBound on empty histogram")
+	}
+
+	return (int64)(*h.buckets[len(h.buckets)-1].upperBound.(*tree.DInt))
+}
+
+// newHistogram creates a new histogram given new buckets which represent
+// a filtered version of the existing histogram h.
+func (h *histogram) newHistogram(newBuckets []bucket) *histogram {
+	checkBucketsValid(newBuckets)
+
 	total := int64(0)
 	for _, b := range newBuckets {
 		total += b.numEq + b.numRange
 	}
 
-	selectivity := float64(total) / float64(h.rowCount)
-	return &histogram{
-		rowCount: total,
+	if total == 0 {
+		return &histogram{}
+	}
 
-		// Estimate the new distinctCount based on the selectivity of this filter.
-		// todo(rytaft): this could be more precise if we take into account the
-		// null count of the original histogram.
-		distinctCount: int64(float64(h.distinctCount) * selectivity),
+	selectivity := float64(total) / float64(h.rowCount)
+
+	// Estimate the new distinctCount based on the selectivity of this filter.
+	// todo(rytaft): this could be more precise if we take into account the
+	// null count of the original histogram. This could also be more precise for
+	// the operators =, !=, in, and not in, since we know how these operators
+	// should affect the distinct count.
+	distinctCount := int64(float64(h.distinctCount) * selectivity)
+	if distinctCount == 0 {
+		// There must be at least one distinct value since rowCount > 0.
+		distinctCount++
+	}
+	return &histogram{
+		rowCount:      total,
+		distinctCount: distinctCount,
 
 		// All the returned rows will be non-null for this column.
-		nullCount:  0,
-		lowerBound: lowerBound,
-		buckets:    newBuckets,
+		nullCount: 0,
+		buckets:   newBuckets,
 	}
 }
 
 // filterHistogramLtOpLeOp applies a filter to the histogram that compares
 // the histogram column value to a constant value with a ltOp or leOp (e.g., x < 4).
 // Returns an updated histogram including only the values that satisfy the predicate.
+//
+// Currently only works for integer valued columns. This will need to be altered
+// for floating point columns and other types.
 func (h *histogram) filterHistogramLtOpLeOp(op operator, val int64) *histogram {
 	if op != ltOp && op != leOp {
 		panic("filterHistogramLtOpLeOp called with operator " + op.String())
 	}
 
-	// NB: The following logic only works for integer valued columns. This will need to
-	// be altered for floating point columns and other types.
-	lowerBound := (int64)(*h.lowerBound.(*tree.DInt))
+	if len(h.buckets) == 0 {
+		return h
+	}
+
+	lowerBound := h.getLowerBound()
 	var newBuckets []bucket
+
 	for _, b := range h.buckets {
 		if val <= lowerBound {
 			break
 		}
-		upperBound := (int64)(*b.upperBound.(*tree.DInt))
-		if val < upperBound {
-			// The bucket size calculation has a -1 because numRange does not
-			// include values equal to upperBound.
-			bucketSize := upperBound - lowerBound - 1
-			if bucketSize > 0 {
-				var bucketMatchSize int64
-				var newUpperBound int64
-				if op == leOp {
-					// The matching values include val for leOp.
-					bucketMatchSize = val - lowerBound
-					newUpperBound = val + 1
-				} else { /* op == ltOp */
-					// The matching values do not include val for ltOp.
-					bucketMatchSize = val - lowerBound - 1
-					newUpperBound = val
-				}
 
-				// Create the new bucket.
-				buc := bucket{
-					numEq: 0,
-					// Assuming a uniform distribution.
-					numRange: (int64)(float64(b.numRange) * float64(bucketMatchSize) / float64(bucketSize)),
-				}
-				v := &tree.NumVal{Value: constant.MakeInt64(newUpperBound)}
-				var err error
-				buc.upperBound, err = v.ResolveAsType(nil, types.Int)
-				if err != nil {
-					fatalf("malformed histogram bucket: %s: %v", v, err)
-				}
-				newBuckets = append(newBuckets, buc)
+		upperBound := (int64)(*b.upperBound.(*tree.DInt))
+		if val <= upperBound {
+			var buc bucket
+			if val < upperBound {
+				buc, _ = b.splitBucket(val, lowerBound)
+			} else {
+				buc = b
 			}
-			break
-		}
-		if val == upperBound {
-			buc := b
+
 			if op == ltOp {
 				buc.numEq = 0
 			}
@@ -289,28 +429,38 @@ func (h *histogram) filterHistogramLtOpLeOp(op operator, val int64) *histogram {
 		lowerBound = upperBound
 	}
 
-	return h.newHistogram(newBuckets, h.lowerBound)
+	return h.newHistogram(newBuckets)
 }
 
 // filterHistogramGtOpGeOp applies a filter to the histogram that compares
 // the histogram column value to a constant value with a gtOp or geOp (e.g., x > 4).
 // Returns an updated histogram including only the values that satisfy the predicate.
+//
+// Currently only works for integer valued columns. This will need to be altered
+// for floating point columns and other types.
 func (h *histogram) filterHistogramGtOpGeOp(op operator, val int64) *histogram {
 	if op != gtOp && op != geOp {
 		panic("filterHistogramGtOpGeOp called with operator " + op.String())
 	}
 
-	// NB: The following logic only works for integer valued columns. This will need to
-	// be altered for floating point columns and other types.
+	if len(h.buckets) == 0 {
+		return h
+	}
+
+	upperBound := h.getUpperBound()
 	var newBuckets []bucket
+
+	newLowerBound := val
+	if op == geOp {
+		newLowerBound -= 1
+	}
+
+	// Iterate backwards through the buckets to avoid scanning buckets
+	// that don't satisfy the predicate.
 	for i := len(h.buckets) - 1; i >= 0; i-- {
 		b := h.buckets[i]
-		upperBound := (int64)(*b.upperBound.(*tree.DInt))
-		if val > upperBound {
-			break
-		}
-		if val == upperBound {
-			if op == geOp {
+		if val >= upperBound {
+			if val == upperBound && op == geOp {
 				buc := b
 				buc.numRange = 0
 				newBuckets = append(newBuckets, buc)
@@ -320,35 +470,24 @@ func (h *histogram) filterHistogramGtOpGeOp(op operator, val int64) *histogram {
 
 		var lowerBound int64
 		if i == 0 {
-			lowerBound = (int64)(*h.lowerBound.(*tree.DInt))
+			lowerBound = upperBound - 1
 		} else {
 			lowerBound = (int64)(*h.buckets[i-1].upperBound.(*tree.DInt))
 		}
 		if val > lowerBound {
-			// The bucket size calculation has a -1 because numRange does not
-			// include values equal to upperBound.
-			bucketSize := upperBound - lowerBound - 1
-			numRange := int64(0)
-			if bucketSize > 0 {
-				var bucketMatchSize int64
-				if op == geOp {
-					// The matching values include val for geOp.
-					bucketMatchSize = upperBound - val
-				} else { /* op == gtOp */
-					// The matching values do not include val for gtOp.
-					bucketMatchSize = upperBound - val - 1
-				}
-
-				// Assuming a uniform distribution.
-				numRange = (int64)(float64(b.numRange) * float64(bucketMatchSize) / float64(bucketSize))
-			}
-			buc := b
-			buc.numRange = numRange
+			_, buc := b.splitBucket(newLowerBound, lowerBound)
 			newBuckets = append(newBuckets, buc)
 			break
 		}
 
 		newBuckets = append(newBuckets, b)
+		upperBound = lowerBound
+	}
+
+	// Add a dummy bucket for the lower bound if needed.
+	if len(newBuckets) > 0 && newBuckets[len(newBuckets)-1].numRange != 0 {
+		buc := newBucket(newLowerBound, 0 /* numRange */, 0 /* numEq */)
+		newBuckets = append(newBuckets, buc)
 	}
 
 	// Reverse the buckets so they are sorted in ascending order.
@@ -356,17 +495,105 @@ func (h *histogram) filterHistogramGtOpGeOp(op operator, val int64) *histogram {
 		newBuckets[i], newBuckets[j] = newBuckets[j], newBuckets[i]
 	}
 
-	// Find the new lower bound of the histogram.
-	var newLowerBound int64
-	if op == geOp {
-		newLowerBound = val - 1
-	} else { /* op == gtOp */
-		newLowerBound = val
+	return h.newHistogram(newBuckets)
+}
+
+// filterHistogramEqOpInOp applies a filter to the histogram that compares
+// the histogram column value to a constant value or set of values with an
+// eqOp (e.g., x == 4) or an inOp (e.g., x in (4, 5, 6)).
+// Returns an updated histogram including only the values that satisfy the predicate.
+//
+// Currently only works for integer valued columns. This will need to be altered
+// for floating point columns and other types.
+func (h *histogram) filterHistogramEqOpInOp(vals []int64) *histogram {
+	if len(vals) == 0 {
+		return &histogram{}
 	}
-	v := &tree.NumVal{Value: constant.MakeInt64(newLowerBound)}
-	lb, err := v.ResolveAsType(nil, types.Int)
-	if err != nil {
-		fatalf("could not create lower bound Datum: %s: %v", v, err)
+
+	if len(h.buckets) == 0 {
+		return h
 	}
-	return h.newHistogram(newBuckets, lb)
+
+	sortkeys.Int64s(vals)
+	valIdx := 0
+	lowerBound := h.getLowerBound()
+	var newBuckets []bucket
+
+	for _, b := range h.buckets {
+		if valIdx >= len(vals) {
+			break
+		}
+
+		for valIdx < len(vals) && vals[valIdx] <= lowerBound {
+			valIdx++
+		}
+
+		upperBound := (int64)(*b.upperBound.(*tree.DInt))
+		bucketSize := upperBound - lowerBound - 1
+		for valIdx < len(vals) && vals[valIdx] < upperBound && bucketSize > 0 {
+			// Assuming a uniform distribution.
+			numEq := (int64)(float64(b.numRange) / float64(bucketSize))
+			buc := newBucket(vals[valIdx], 0 /* numRange */, numEq)
+			newBuckets = append(newBuckets, buc)
+			valIdx++
+		}
+
+		for valIdx < len(vals) && vals[valIdx] == upperBound {
+			buc := b
+			buc.numRange = 0
+			newBuckets = append(newBuckets, buc)
+			valIdx++
+		}
+
+		lowerBound = upperBound
+	}
+
+	return h.newHistogram(newBuckets)
+}
+
+// filterHistogramNeOpNotInOp applies a filter to the histogram that compares
+// the histogram column value to a constant value or set of values with a
+// neOp (e.g., x != 4) or notInOp (e.g., x not in (4, 5, 6)).
+// Returns an updated histogram including only the values that satisfy the predicate.
+//
+// Currently only works for integer valued columns. This will need to be altered
+// for floating point columns and other types.
+func (h *histogram) filterHistogramNeOpNotInOp(vals []int64) *histogram {
+	if len(vals) == 0 || len(h.buckets) == 0 {
+		return h
+	}
+
+	sortkeys.Int64s(vals)
+	valIdx := 0
+	lowerBound := h.getLowerBound()
+	var newBuckets []bucket
+
+	for _, b := range h.buckets {
+		for valIdx < len(vals) && vals[valIdx] <= lowerBound {
+			valIdx++
+		}
+
+		buc := b
+		upperBound := (int64)(*b.upperBound.(*tree.DInt))
+		for valIdx < len(vals) && vals[valIdx] > lowerBound && vals[valIdx] < upperBound {
+			var bucLower bucket
+			// Upper bucket will either be split again or added once this inner
+			// loop terminates.
+			bucLower, buc = buc.splitBucket(vals[valIdx], lowerBound)
+			bucLower.numEq = 0
+			newBuckets = append(newBuckets, bucLower)
+			lowerBound = vals[valIdx]
+			valIdx++
+		}
+
+		for valIdx < len(vals) && vals[valIdx] == upperBound {
+			buc.numEq = 0
+			valIdx++
+		}
+
+		newBuckets = append(newBuckets, buc)
+		lowerBound = upperBound
+	}
+
+	return h.newHistogram(newBuckets)
 }

--- a/v3/testdata/stats
+++ b/v3/testdata/stats
@@ -10,14 +10,36 @@ INSERT INTO histogram.a.x VALUES
   ('rows', 1000),
   ('distinct', 100),
   ('nulls', 10),
-  ('lowerBound', 0),
-  (4, 5, 2), (2, 3, 3), (100, 976, 1)
+  (0, 0, 0), (4, 5, 2), (2, 3, 3), (100, 976, 1)
 ----
 rows:       1000
 distinct:   100
 nulls:      10
-lowerBound: 0
-buckets:    2:3,3 4:5,2 100:976,1
+buckets:    0:0,0 2:3,3 4:5,2 100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x < 0
+----
+rows:       0
+distinct:   0
+nulls:      0
+buckets:    none
+
+exec
+SELECT * FROM histogram.a.x WHERE x = 0
+----
+rows:       0
+distinct:   0
+nulls:      0
+buckets:    none
+
+exec
+SELECT * FROM histogram.a.x WHERE x != 0
+----
+rows:       990
+distinct:   99
+nulls:      0
+buckets:    0:0,0 2:3,3 4:5,2 100:976,1
 
 exec
 SELECT * FROM histogram.a.x WHERE x < 4
@@ -25,8 +47,7 @@ SELECT * FROM histogram.a.x WHERE x < 4
 rows:       11
 distinct:   1
 nulls:      0
-lowerBound: 0
-buckets:    2:3,3 4:5,0
+buckets:    0:0,0 2:3,3 4:5,0
 
 exec
 SELECT * FROM histogram.a.x WHERE x <= 4
@@ -34,8 +55,7 @@ SELECT * FROM histogram.a.x WHERE x <= 4
 rows:       13
 distinct:   1
 nulls:      0
-lowerBound: 0
-buckets:    2:3,3 4:5,2
+buckets:    0:0,0 2:3,3 4:5,2
 
 exec
 SELECT * FROM histogram.a.x WHERE x > 4
@@ -43,8 +63,7 @@ SELECT * FROM histogram.a.x WHERE x > 4
 rows:       977
 distinct:   97
 nulls:      0
-lowerBound: 4
-buckets:    100:976,1
+buckets:    4:0,0 100:976,1
 
 exec
 SELECT * FROM histogram.a.x WHERE x >= 4
@@ -52,8 +71,23 @@ SELECT * FROM histogram.a.x WHERE x >= 4
 rows:       979
 distinct:   97
 nulls:      0
-lowerBound: 3
 buckets:    4:0,2 100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x = 4
+----
+rows:       2
+distinct:   1
+nulls:      0
+buckets:    4:0,2
+
+exec
+SELECT * FROM histogram.a.x WHERE x != 4
+----
+rows:       988
+distinct:   98
+nulls:      0
+buckets:    0:0,0 2:3,3 4:5,0 100:976,1
 
 exec
 SELECT * FROM histogram.a.x WHERE x < 50
@@ -61,8 +95,7 @@ SELECT * FROM histogram.a.x WHERE x < 50
 rows:       475
 distinct:   47
 nulls:      0
-lowerBound: 0
-buckets:    2:3,3 4:5,2 50:462,0
+buckets:    0:0,0 2:3,3 4:5,2 50:462,0
 
 exec
 SELECT * FROM histogram.a.x WHERE x <= 50
@@ -70,8 +103,7 @@ SELECT * FROM histogram.a.x WHERE x <= 50
 rows:       485
 distinct:   48
 nulls:      0
-lowerBound: 0
-buckets:    2:3,3 4:5,2 51:472,0
+buckets:    0:0,0 2:3,3 4:5,2 50:462,10
 
 exec
 SELECT * FROM histogram.a.x WHERE x > 50
@@ -79,8 +111,7 @@ SELECT * FROM histogram.a.x WHERE x > 50
 rows:       504
 distinct:   50
 nulls:      0
-lowerBound: 50
-buckets:    100:503,1
+buckets:    50:0,0 100:503,1
 
 exec
 SELECT * FROM histogram.a.x WHERE x >= 50
@@ -88,5 +119,60 @@ SELECT * FROM histogram.a.x WHERE x >= 50
 rows:       514
 distinct:   51
 nulls:      0
-lowerBound: 49
-buckets:    100:513,1
+buckets:    49:0,0 100:513,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x = 50
+----
+rows:       10
+distinct:   1
+nulls:      0
+buckets:    50:0,10
+
+exec
+SELECT * FROM histogram.a.x WHERE x != 50
+----
+rows:       979
+distinct:   97
+nulls:      0
+buckets:    0:0,0 2:3,3 4:5,2 50:462,0 100:503,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x > 100
+----
+rows:       0
+distinct:   0
+nulls:      0
+buckets:    none
+
+exec
+SELECT * FROM histogram.a.x WHERE x = 101
+----
+rows:       0
+distinct:   0
+nulls:      0
+buckets:    none
+
+exec
+SELECT * FROM histogram.a.x WHERE x != 101
+----
+rows:       990
+distinct:   99
+nulls:      0
+buckets:    0:0,0 2:3,3 4:5,2 100:976,1
+
+exec
+SELECT * FROM histogram.a.x WHERE x in (0, 4, 50, 75, 101)
+----
+rows:       22
+distinct:   2
+nulls:      0
+buckets:    0:0,0 4:0,2 50:0,10 75:0,10
+
+exec
+SELECT * FROM histogram.a.x WHERE x not in (0, 4, 50, 75, 101)
+----
+rows:       966
+distinct:   96
+nulls:      0
+buckets:    0:0,0 2:3,3 4:5,0 50:462,0 75:246,0 100:246,1


### PR DESCRIPTION
Add functions to filter a histogram for the operators
eqOp, neOp, inOp and notInOp. These operators correspond
to predicates such as x = 4, x != 4, x in (4, 5, 6) and
x not in (4, 5, 6). The result of these new functions
is a histogram including only the valuse that satisfy
the predicate.

cc @RaduBerinde

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/42)
<!-- Reviewable:end -->
