### PR TITLE
Add filter inference, normalization and push-down logic to v4

### DIFF
--- a/v4/build/builder.go
+++ b/v4/build/builder.go
@@ -411,7 +411,7 @@ func (b *Builder) buildScalarProjection(texpr tree.TypedExpr, inScope, outScope 
 	case *tree.ParenExpr:
 		return b.buildScalarProjection(t.TypedInnerExpr(), inScope, outScope)
 
-	case tree.UnresolvedName:
+	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()
 		if err != nil {
 			panic(err)
@@ -525,7 +525,7 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) opt.GroupID
 	case tree.UnqualifiedStar:
 		fatalf("unexpected unresolved scalar expr: %T", scalar)
 
-	case tree.UnresolvedName:
+	case *tree.UnresolvedName:
 		fatalf("unexpected unresolved scalar expr: %T", scalar)
 
 		// NB: this is the exception to the sorting of the case statements. The
@@ -905,7 +905,7 @@ func (b *Builder) buildProjection(projection tree.Expr, inScope, outScope *scope
 		}
 		return
 
-	case tree.UnresolvedName:
+	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()
 		if err != nil {
 			panic(err)

--- a/v4/build/column_props.go
+++ b/v4/build/column_props.go
@@ -26,9 +26,10 @@ var _ tree.VariableExpr = &columnProps{}
 
 func (c columnProps) String() string {
 	if c.table == "" {
-		return tree.Name(c.name).String()
+		return tree.NameString(string(c.name))
 	}
-	return fmt.Sprintf("%s.%s", tree.Name(c.table), tree.Name(c.name))
+	return fmt.Sprintf("%s.%s",
+		tree.NameString(string(c.table)), tree.NameString(string(c.name)))
 }
 
 func (c columnProps) matches(tblName cat.TableName, colName cat.ColumnName) bool {

--- a/v4/opt/factory.og.go
+++ b/v4/opt/factory.og.go
@@ -234,6 +234,40 @@ func (_f *Factory) ConstructLt(
 		return _group
 	}
 
+	if _f.maxSteps <= 0 {
+		return _f.mem.memoizeNormExpr((*memoExpr)(&_ltExpr))
+	}
+
+	// [NormalizeInequalityVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.maxSteps--
+				_group = _f.commuteInequalityExpr(LtOp, left, right)
+				_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeInequalityVarOrder]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable != nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				if _f.isLowerExpr(right, left) {
+					_f.maxSteps--
+					_group = _f.commuteInequalityExpr(LtOp, left, right)
+					_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_ltExpr)))
 }
 
@@ -245,6 +279,40 @@ func (_f *Factory) ConstructGt(
 	_group := _f.mem.lookupGroupByFingerprint(_gtExpr.fingerprint())
 	if _group != 0 {
 		return _group
+	}
+
+	if _f.maxSteps <= 0 {
+		return _f.mem.memoizeNormExpr((*memoExpr)(&_gtExpr))
+	}
+
+	// [NormalizeInequalityVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.maxSteps--
+				_group = _f.commuteInequalityExpr(GtOp, left, right)
+				_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeInequalityVarOrder]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable != nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				if _f.isLowerExpr(right, left) {
+					_f.maxSteps--
+					_group = _f.commuteInequalityExpr(GtOp, left, right)
+					_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_gtExpr)))
@@ -260,6 +328,40 @@ func (_f *Factory) ConstructLe(
 		return _group
 	}
 
+	if _f.maxSteps <= 0 {
+		return _f.mem.memoizeNormExpr((*memoExpr)(&_leExpr))
+	}
+
+	// [NormalizeInequalityVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.maxSteps--
+				_group = _f.commuteInequalityExpr(LeOp, left, right)
+				_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeInequalityVarOrder]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable != nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				if _f.isLowerExpr(right, left) {
+					_f.maxSteps--
+					_group = _f.commuteInequalityExpr(LeOp, left, right)
+					_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_leExpr)))
 }
 
@@ -271,6 +373,40 @@ func (_f *Factory) ConstructGe(
 	_group := _f.mem.lookupGroupByFingerprint(_geExpr.fingerprint())
 	if _group != 0 {
 		return _group
+	}
+
+	if _f.maxSteps <= 0 {
+		return _f.mem.memoizeNormExpr((*memoExpr)(&_geExpr))
+	}
+
+	// [NormalizeInequalityVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.maxSteps--
+				_group = _f.commuteInequalityExpr(GeOp, left, right)
+				_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeInequalityVarOrder]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable != nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				if _f.isLowerExpr(right, left) {
+					_f.maxSteps--
+					_group = _f.commuteInequalityExpr(GeOp, left, right)
+					_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_geExpr)))
@@ -847,6 +983,26 @@ func (_f *Factory) ConstructSelect(
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_selectExpr))
 	}
 
+	// [MergeSelectSelect]
+	{
+		_select := _f.mem.lookupNormExpr(input).asSelect()
+		if _select != nil {
+			input := _select.input()
+			innerFilter := _select.filter()
+			_filters := _f.mem.lookupNormExpr(_select.filter()).asFilters()
+			if _filters != nil {
+				outerFilter := filter
+				_filters2 := _f.mem.lookupNormExpr(filter).asFilters()
+				if _filters2 != nil {
+					_f.maxSteps--
+					_group = _f.ConstructSelect(input, _f.concatFilterConditions(outerFilter, innerFilter))
+					_f.mem.addAltFingerprint(_selectExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
 	// [EliminateSelect]
 	{
 		_true := _f.mem.lookupNormExpr(filter).asTrue()
@@ -864,7 +1020,7 @@ func (_f *Factory) ConstructSelect(
 		if _filters == nil {
 			if _f.useFilters(filter) {
 				_f.maxSteps--
-				_group = _f.ConstructSelect(input, _f.flattenFilterCondition(filter))
+				_group = _f.ConstructSelect(input, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{input}), filter))
 				_f.mem.addAltFingerprint(_selectExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1031,7 +1187,7 @@ func (_f *Factory) ConstructInnerJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructInnerJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructInnerJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_innerJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1099,7 +1255,7 @@ func (_f *Factory) ConstructLeftJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructLeftJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructLeftJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_leftJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1167,7 +1323,7 @@ func (_f *Factory) ConstructRightJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructRightJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructRightJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_rightJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1235,7 +1391,7 @@ func (_f *Factory) ConstructFullJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructFullJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructFullJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_fullJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1303,7 +1459,7 @@ func (_f *Factory) ConstructSemiJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructSemiJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructSemiJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_semiJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1371,7 +1527,7 @@ func (_f *Factory) ConstructAntiJoin(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructAntiJoin(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructAntiJoin(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_antiJoinExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1439,7 +1595,7 @@ func (_f *Factory) ConstructInnerJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructInnerJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructInnerJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_innerJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1562,7 +1718,7 @@ func (_f *Factory) ConstructLeftJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructLeftJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructLeftJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_leftJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1653,7 +1809,7 @@ func (_f *Factory) ConstructRightJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructRightJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructRightJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_rightJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1744,7 +1900,7 @@ func (_f *Factory) ConstructFullJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructFullJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructFullJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_fullJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1850,7 +2006,7 @@ func (_f *Factory) ConstructSemiJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructSemiJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructSemiJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_semiJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}
@@ -1975,7 +2131,7 @@ func (_f *Factory) ConstructAntiJoinApply(
 		if _filters == nil {
 			if _f.useFilters(on) {
 				_f.maxSteps--
-				_group = _f.ConstructAntiJoinApply(left, right, _f.flattenFilterCondition(on))
+				_group = _f.ConstructAntiJoinApply(left, right, _f.flattenFilterCondition(_f.mem.storeList([]GroupID{left, right}), on))
 				_f.mem.addAltFingerprint(_antiJoinApplyExpr.fingerprint(), _group)
 				return _group
 			}

--- a/v4/opt/norm/filter.opt
+++ b/v4/opt/norm/filter.opt
@@ -30,7 +30,7 @@
 =>
 (Select
     $input
-    (FlattenFilterCondition $filter)
+    (FlattenFilterCondition [ $input ] $filter)
 )
 
 # EnsureJoinFilters adds a Filters operator to the join operator's filter
@@ -46,5 +46,5 @@
 ((OpName)
     $left
     $right
-    (FlattenFilterCondition $on)
+    (FlattenFilterCondition [ $left $right ] $on)
 )

--- a/v4/opt/norm/norm.opt
+++ b/v4/opt/norm/norm.opt
@@ -24,6 +24,26 @@
 =>
 ((OpName) $right $left)
 
+# NormalizeInequalityVar ensures that variable references are on the left side
+# of inequality operators.
+[NormalizeInequalityVar, Normalize]
+(Le | Lt | Ge | Gt
+    $left:^(Variable)
+    $right:(Variable)
+)
+=>
+(CommuteInequalityExpr (OpName) $left $right)
+
+# NormalizeInequalityVarOrder establishes an arbitrary, but canonical ordering
+# of inequality operators where both operands are variables.
+[NormalizeInequalityVarOrder, Normalize]
+(Le | Lt | Ge | Gt
+    $left:(Variable)
+    $right:(Variable) & (IsLowerExpr $right $left)
+)
+=>
+(CommuteInequalityExpr (OpName) $left $right)
+
 # EliminateProject discards the unnecessary project operator when the projected
 # columns are the same as the input operand's columns.
 [EliminateProject, Normalize]
@@ -40,3 +60,15 @@
 )
 =>
 ((OpName) $left $input (True))
+
+# MergeSelectSelect discards unnecessary nesting of Select statements.
+[MergeSelectSelect, Normalize]
+(Select
+  (Select $input:* $innerFilter:(Filters))
+  $outerFilter:(Filters)
+)
+=>
+(Select
+  $input
+  (ConcatFilterConditions $outerFilter $innerFilter)
+)

--- a/v4/testdata/decorrelate
+++ b/v4/testdata/decorrelate
@@ -104,6 +104,6 @@ arrange
       │         └── function: sum [unbound=(4)]
       │              └── variable: b.z [unbound=(4)]
       └── filters [unbound=(5)]
-           └── lt [unbound=(5)]
-                ├── const: 1000000
-                └── variable: column1 [unbound=(5)]
+           └── gt [unbound=(5)]
+                ├── variable: column1 [unbound=(5)]
+                └── const: 1000000

--- a/v4/testdata/normalize
+++ b/v4/testdata/normalize
@@ -1,0 +1,23 @@
+exec
+CREATE TABLE a (x INT, y INT)
+----
+table a
+  x NULL
+  y NULL
+
+normalize
+SELECT a.* FROM a WHERE 5 > x and x > 1
+----
+arrange
+ ├── columns: x:1* y:2
+ └── select
+      ├── columns: a.x:1* a.y:2
+      ├── scan
+      │    └── columns: a.x:1 a.y:2
+      └── filters [unbound=(1)]
+           ├── lt [unbound=(1)]
+           │    ├── variable: a.x [unbound=(1)]
+           │    └── const: 5
+           └── gt [unbound=(1)]
+                ├── variable: a.x [unbound=(1)]
+                └── const: 1

--- a/v4/testdata/push_down
+++ b/v4/testdata/push_down
@@ -37,10 +37,13 @@ project
  │    │              ├── variable: a.x [unbound=(1)]
  │    │              └── placeholder: $1
  │    ├── select
- │    │    ├── columns: b.x:3 b.z:4*
+ │    │    ├── columns: b.x:3* b.z:4*
  │    │    ├── scan
  │    │    │    └── columns: b.x:3 b.z:4
- │    │    └── filters [unbound=(4)]
+ │    │    └── filters [unbound=(3,4)]
+ │    │         ├── gt [unbound=(3)]
+ │    │         │    ├── variable: b.x [unbound=(3)]
+ │    │         │    └── placeholder: $1
  │    │         └── eq [unbound=(4)]
  │    │              ├── variable: b.z [unbound=(4)]
  │    │              └── placeholder: $2
@@ -51,3 +54,38 @@ project
  └── projections [unbound=(2,4)]
       ├── variable: a.y [unbound=(2)]
       └── variable: b.z [unbound=(4)]
+
+normalize
+SELECT * FROM a JOIN b ON (a.x = b.x) WHERE a.y + b.x = 1
+----
+arrange
+ ├── columns: x:1* y:2* x:3* z:4
+ ├── equiv: (1,3)
+ └── select
+      ├── columns: a.x:1* a.y:2* b.x:3* b.z:4
+      ├── equiv: (1,3)
+      ├── inner-join
+      │    ├── columns: a.x:1* a.y:2* b.x:3* b.z:4
+      │    ├── equiv: (1,3)
+      │    ├── select
+      │    │    ├── columns: a.x:1* a.y:2*
+      │    │    ├── scan
+      │    │    │    └── columns: a.x:1 a.y:2
+      │    │    └── filters [unbound=(1,2)]
+      │    │         └── eq [unbound=(1,2)]
+      │    │              ├── plus [unbound=(1,2)]
+      │    │              │    ├── variable: a.y [unbound=(2)]
+      │    │              │    └── variable: a.x [unbound=(1)]
+      │    │              └── const: 1
+      │    ├── scan
+      │    │    └── columns: b.x:3 b.z:4
+      │    └── filters [unbound=(1,3)]
+      │         └── eq [unbound=(1,3)]
+      │              ├── variable: a.x [unbound=(1)]
+      │              └── variable: b.x [unbound=(3)]
+      └── filters [unbound=(2,3)]
+           └── eq [unbound=(2,3)]
+                ├── plus [unbound=(2,3)]
+                │    ├── variable: a.y [unbound=(2)]
+                │    └── variable: b.x [unbound=(3)]
+                └── const: 1


### PR DESCRIPTION
This PR makes a few small updates to the transformation logic
in the `v4` version of opttoy:
1. Normalize comparison expressions so the variable is always on
   the left.  E.g., `5 > x` -> `x < 5`. This was already the case for
   equals and not-equals (= and !=), but this commit adds the
   inequalities <, <=, >, and >=.
2. Infer filters on equivalent columns. For example, if two columns
   x and y are equal, and there is already a filter on `x` (e.g. `x < 5`),
   then an additional filter is added for `y` (`y < 5`).
3. Fix the push-down logic so that multiple filters on the same table
   get pushed down to the same subquery. Previously, a new subquery was
   created for each pushed-down filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/54)
<!-- Reviewable:end -->
