### PR TITLE
Push filters onto inner joins

### DIFF
--- a/v4/build/builder.go
+++ b/v4/build/builder.go
@@ -471,12 +471,6 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) opt.GroupID
 	case tree.DefaultVal:
 		unimplemented("%T", scalar)
 
-	case *tree.ExistsExpr:
-		// TODO(peter): the decorrelation code currently expects the subquery to be
-		// unwrapped for EXISTS expressions.
-		subquery := t.Subquery.(*subquery)
-		return b.factory.ConstructExists(subquery.out)
-
 	case *tree.FuncExpr:
 		out, _ := b.buildFunction(t, inScope)
 		return out
@@ -509,6 +503,10 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) opt.GroupID
 		unimplemented("%T", scalar)
 
 	case *subquery:
+		if t.exists {
+			return b.factory.ConstructExists(t.out)
+		}
+
 		v := b.factory.ConstructVariable(b.factory.InternPrivate(t.cols[0].index))
 		return b.factory.ConstructSubquery(t.out, v)
 

--- a/v4/build/scope.go
+++ b/v4/build/scope.go
@@ -278,13 +278,12 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 			}
 		}
 
-	case *tree.ExistsExpr:
-		if sub, ok := t.Subquery.(*tree.Subquery); ok {
-			t.Subquery = s.replaceSubquery(sub, true /* multi-row */, -1 /* desired-columns */)
-		}
-
 	case *tree.Subquery:
-		expr = s.replaceSubquery(t, false /* multi-row */, s.columns /* desired-columns */)
+		if t.Exists {
+			expr = s.replaceSubquery(t, true /* multi-row */, -1 /* desired-columns */)
+		} else {
+			expr = s.replaceSubquery(t, false /* multi-row */, s.columns /* desired-columns */)
+		}
 	}
 
 	// Reset the desired number of columns since if the subquery is a child of
@@ -339,11 +338,18 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 		}
 	}
 
-	return &subquery{
+	subOut := &subquery{
 		cols:     outScope.cols,
 		out:      out,
 		multiRow: multiRow,
+		exists:   sub.Exists,
 	}
+
+	if sub.Exists {
+		subOut.typ = types.Bool
+	}
+
+	return subOut
 }
 
 type subquery struct {
@@ -355,6 +361,9 @@ type subquery struct {
 
 	// typ is the lazily resolved type of the subquery.
 	typ types.T
+
+	// Is this an EXISTS statement?
+	exists bool
 }
 
 // String implements the tree.Expr interface.

--- a/v4/opt/memo.go
+++ b/v4/opt/memo.go
@@ -192,7 +192,7 @@ func (m *memo) storeList(items []GroupID) ListID {
 }
 
 func (m *memo) lookupList(id ListID) []GroupID {
-	return m.lists[id.offset : id.offset+id.len]
+	return m.lists[id.offset : id.offset+id.len : id.offset+id.len]
 }
 
 func (m *memo) internPrivate(private interface{}) PrivateID {

--- a/v4/opt/norm/push_down.opt
+++ b/v4/opt/norm/push_down.opt
@@ -28,6 +28,20 @@
     (Filters (RemoveListItem $list $condition))
 )
 
+# PushDownSelectJoin pushes all filter conditions from a select on to an inner
+# join and removes the select.
+[PushDownSelectJoin, Normalize]
+(Select
+    $input:(InnerJoin|InnerJoinApply $left:* $right:* $on:*)
+    $filter:*
+)
+=>
+((OpName $input)
+    $left
+    $right
+    (ConcatFilterConditions $on $filter)
+)
+
 [PushDownJoinFilter, Normalize]
 (Join
     $left:*

--- a/v4/testdata/push_down
+++ b/v4/testdata/push_down
@@ -61,29 +61,25 @@ SELECT * FROM a JOIN b ON (a.x = b.x) WHERE a.y + b.x = 1
 arrange
  ├── columns: x:1* y:2* x:3* z:4
  ├── equiv: (1,3)
- └── select
+ └── inner-join
       ├── columns: a.x:1* a.y:2* b.x:3* b.z:4
       ├── equiv: (1,3)
-      ├── inner-join
-      │    ├── columns: a.x:1* a.y:2* b.x:3* b.z:4
-      │    ├── equiv: (1,3)
-      │    ├── select
-      │    │    ├── columns: a.x:1* a.y:2*
-      │    │    ├── scan
-      │    │    │    └── columns: a.x:1 a.y:2
-      │    │    └── filters [unbound=(1,2)]
-      │    │         └── eq [unbound=(1,2)]
-      │    │              ├── plus [unbound=(1,2)]
-      │    │              │    ├── variable: a.y [unbound=(2)]
-      │    │              │    └── variable: a.x [unbound=(1)]
-      │    │              └── const: 1
+      ├── select
+      │    ├── columns: a.x:1* a.y:2*
       │    ├── scan
-      │    │    └── columns: b.x:3 b.z:4
-      │    └── filters [unbound=(1,3)]
-      │         └── eq [unbound=(1,3)]
-      │              ├── variable: a.x [unbound=(1)]
-      │              └── variable: b.x [unbound=(3)]
-      └── filters [unbound=(2,3)]
+      │    │    └── columns: a.x:1 a.y:2
+      │    └── filters [unbound=(1,2)]
+      │         └── eq [unbound=(1,2)]
+      │              ├── plus [unbound=(1,2)]
+      │              │    ├── variable: a.y [unbound=(2)]
+      │              │    └── variable: a.x [unbound=(1)]
+      │              └── const: 1
+      ├── scan
+      │    └── columns: b.x:3 b.z:4
+      └── filters [unbound=(1-3)]
+           ├── eq [unbound=(1,3)]
+           │    ├── variable: a.x [unbound=(1)]
+           │    └── variable: b.x [unbound=(3)]
            └── eq [unbound=(2,3)]
                 ├── plus [unbound=(2,3)]
                 │    ├── variable: a.y [unbound=(2)]


### PR DESCRIPTION
This commit adds a simple pattern to push a filter onto an
inner join if it can't be pushed below. This is going to be
important for queries where the `ON` condition isn't explicitly
specified. For example, `SELECT * FROM a, b WHERE a.x = b.x`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/opttoy/55)
<!-- Reviewable:end -->
